### PR TITLE
#43 the unwrap call has been replaced with converting into error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 Cargo.lock
 target
 *.bk
+.idea/
+cdrs.iml

--- a/src/transport_ssl.rs
+++ b/src/transport_ssl.rs
@@ -2,7 +2,6 @@ use std::io;
 use std::io::{Read, Write};
 use std::net;
 use std::net::TcpStream;
-use std::io::{ErrorKind};
 use openssl::ssl::{SslStream, SslConnector,HandshakeError};
 
 pub struct Transport {
@@ -54,8 +53,7 @@ impl Transport {
     }
 
     pub fn close(&mut self, _close: net::Shutdown) -> io::Result<()> {
-        self.ssl.shutdown().unwrap();
-        return Ok(());
+        return self.ssl.shutdown().map_err(|e| io::Error::new(io::ErrorKind::Other,e)).and_then(|_| Ok(()));
     }
 }
 


### PR DESCRIPTION
the unwrap call on transport_ssl.rs was panic-ing the rust thread #43 
I have replaced the unwrap call with error handling so that thread doesn't panic.
I have left transformations as comments in the code itself