### PR TITLE
Feature/without clone

### DIFF
--- a/src/authenticators.rs
+++ b/src/authenticators.rs
@@ -2,7 +2,7 @@ use types::CBytes;
 
 pub trait Authenticator: Clone {
     fn get_auth_token(&self) -> CBytes;
-    fn get_cassandra_name(&self) -> &str;
+    fn get_cassandra_name(&self) -> Option<&str>;
 }
 
 #[derive(Debug, Clone)]
@@ -30,8 +30,8 @@ impl<'a> Authenticator for PasswordAuthenticator<'a> {
         return CBytes::new(token);
     }
 
-    fn get_cassandra_name(&self) -> &str {
-        return "org.apache.cassandra.auth.PasswordAuthenticator";
+    fn get_cassandra_name(&self) -> Option<&str> {
+        return Some("org.apache.cassandra.auth.PasswordAuthenticator");
     }
 }
 
@@ -44,8 +44,8 @@ impl Authenticator for AuthenticatorNone {
         return CBytes::new(vec![0]);
     }
 
-    fn get_cassandra_name(&self) -> &str {
-        return "NONE";
+    fn get_cassandra_name(&self) -> Option<&str> {
+        return None;
     }
 
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -31,7 +31,6 @@ pub struct Credentials {
 /// CDRS driver structure that provides a basic functionality to work with DB including
 /// establishing new connection, getting supported options, preparing and executing CQL
 /// queries, using compression and other.
-#[derive(Debug)]
 pub struct CDRS<T: Authenticator> {
     compressor: Compression,
     authenticator: T,
@@ -125,7 +124,6 @@ impl<'a, T: Authenticator + 'a> CDRS<T> {
 }
 
 /// The object that provides functionality for communication with Cassandra server.
-#[derive(Debug)]
 pub struct Session<T: Authenticator> {
     started: bool,
     cdrs: CDRS<T>,

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -14,7 +14,6 @@ use transport::Transport;
 use transport_ssl::Transport;
 
 /// [r2d2](https://github.com/sfackler/r2d2) `ManageConnection`.
-#[derive(Debug)]
 pub struct ConnectionManager<T> {
     transport: Transport,
     authenticator: T,

--- a/src/transport_ssl.rs
+++ b/src/transport_ssl.rs
@@ -4,7 +4,7 @@ use std::net;
 use std::net::TcpStream;
 use openssl::ssl::{SslStream, SslConnector,HandshakeError};
 
-#[derive(Debug)]
+
 pub struct Transport {
     ssl: SslStream<TcpStream>,
     connector: SslConnector

--- a/tests/authenticators.rs
+++ b/tests/authenticators.rs
@@ -15,7 +15,7 @@ fn test_password_authenticator_new() {
 #[test]
 fn test_password_authenticator_get_cassandra_name() {
     let auth = PasswordAuthenticator::new("foo", "bar");
-    assert_eq!(auth.get_cassandra_name(), "org.apache.cassandra.auth.PasswordAuthenticator");
+    assert_eq!(auth.get_cassandra_name(), Some("org.apache.cassandra.auth.PasswordAuthenticator"));
 }
 
 #[test]
@@ -32,7 +32,7 @@ fn test_password_authenticator_get_auth_token() {
 #[test]
 fn test_authenticator_none_get_cassandra_name() {
     let auth = AuthenticatorNone;
-    assert_eq!(auth.get_cassandra_name(), "NONE");
+    assert_eq!(auth.get_cassandra_name(), None);
     assert_eq!(auth.get_auth_token().into_plain(), vec![0]);
 }
 


### PR DESCRIPTION
#52 has been resolved and it is now able to speak tls.
now the cassandra_name returns an Option instead of "NONE" string.
earlier pr (which I declined) has clone and i  was fighting with the borrow checker and with this pr; I found a simpler way to get around the borrow checker and without making a clone.
