### PR TITLE
Fix warnings and inconsistent module layout

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -15,10 +15,7 @@ use frame::events::SimpleServerEvent;
 use compression::Compression;
 use authenticators::Authenticator;
 use error;
-#[cfg(not(feature = "ssl"))]
 use transport::Transport;
-#[cfg(feature = "ssl")]
-use transport_ssl::Transport;
 use events::{Listener, EventStream, new_listener};
 
 /// DB user's credentials.

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -8,10 +8,7 @@ use authenticators::Authenticator;
 use compression::Compression;
 use r2d2;
 
-#[cfg(not(feature = "ssl"))]
 use transport::Transport;
-#[cfg(feature = "ssl")]
-use transport_ssl::Transport;
 
 /// [r2d2](https://github.com/sfackler/r2d2) `ManageConnection`.
 pub struct ConnectionManager<T> {

--- a/src/events.rs
+++ b/src/events.rs
@@ -3,10 +3,7 @@ use std::iter::Iterator;
 
 use std::error::Error;
 use error;
-#[cfg(not(feature="ssl"))]
 use transport::Transport;
-#[cfg(feature="ssl")]
-use transport_ssl::Transport;
 use frame::events::{
     ServerEvent as FrameServerEvent,
     SimpleServerEvent as FrameSimpleServerEvent,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub mod query;
 #[cfg(not(feature = "ssl"))]
 pub mod transport;
 #[cfg(feature = "ssl")]
-pub mod transport_ssl;
+pub mod transport;
 
 /// `IntoBytes` should be used to convert a structure into array of bytes.
 pub trait IntoBytes {

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -454,7 +454,7 @@ impl AsRust<Vec<UDT>> for List {
                 let list_type_option_box: Box<ColTypeOption> = type_option.clone();
                 let list_type_option = match list_type_option_box.value {
                     Some(ColTypeOptionValue::UdtType(t)) => t,
-                    _ => return unreachable!()
+                    _ => unreachable!()
                 };
                 match id {
                     // T is Udt


### PR DESCRIPTION
When --all-features was used, the ssl transport
was provided via the `transport_ssl` module.
However, the examples were not prepared for this,
and `cargo test --all-features` would fail.

As both transports are mutually exclusive, it
seems reasonable to just use the same module name
and make life easier for clients.