### PR TITLE
Adopt examples to run with ssl and all features

### DIFF
--- a/examples/batch_queries.rs
+++ b/examples/batch_queries.rs
@@ -1,23 +1,29 @@
+// in feature="ssl" imports are unused until examples are implemented
+#![allow(unused_imports)]
 extern crate cdrs;
 
 use cdrs::client::CDRS;
 use cdrs::query::BatchQueryBuilder;
 use cdrs::authenticators::PasswordAuthenticator;
 use cdrs::compression::Compression;
+#[cfg(not(feature = "ssl"))]
 use cdrs::transport::Transport;
+#[cfg(feature = "ssl")]
+use cdrs::transport_ssl::Transport;
 
 // default credentials
-const USER: &'static str = "cassandra";
-const PASS: &'static str = "cassandra";
-const ADDR: &'static str = "127.0.0.1:9042";
+const _USER: &'static str = "cassandra";
+const _PASS: &'static str = "cassandra";
+const _ADDR: &'static str = "127.0.0.1:9042";
 
 /// First create a keyspace 'keyspace'.
 /// Then create a new table of integers:
 /// CREATE TABLE keyspace.integers (integer int PRIMARY KEY);
 
+#[cfg(not(feature = "ssl"))]
 fn main() {
-    let authenticator = PasswordAuthenticator::new(USER, PASS);
-    let tcp_transport = Transport::new(ADDR).unwrap();
+    let authenticator = PasswordAuthenticator::new(_USER, _PASS);
+    let tcp_transport = Transport::new(_ADDR).unwrap();
     let client = CDRS::new(tcp_transport, authenticator);
     let mut session = client.start(Compression::None).unwrap();
 
@@ -42,4 +48,9 @@ fn main() {
     let batched = session.batch(batch_query, false, false).unwrap();
 
     println!("batch result {:?}", batched.get_body());
+}
+
+#[cfg(feature = "ssl")]
+fn main() {
+    unimplemented!()
 }

--- a/examples/connection_pool.rs
+++ b/examples/connection_pool.rs
@@ -1,3 +1,5 @@
+// in feature="ssl" imports are unused until examples are implemented
+#![allow(unused_imports, unused_variables)]
 extern crate cdrs;
 extern crate r2d2;
 
@@ -5,22 +7,26 @@ use std::thread;
 use std::sync::mpsc::channel;
 
 use cdrs::connection_manager::ConnectionManager;
-use cdrs::transport::Transport;
 use cdrs::authenticators::PasswordAuthenticator;
 use cdrs::compression::Compression;
 use cdrs::query::QueryBuilder;
+#[cfg(not(feature = "ssl"))]
+use cdrs::transport::Transport;
+#[cfg(feature = "ssl")]
+use cdrs::transport_ssl::Transport;
 
 // default credentials
-const USER: &'static str = "cassandra";
-const PASS: &'static str = "cassandra";
-const ADDR: &'static str = "127.0.0.1:9042";
+const _USER: &'static str = "cassandra";
+const _PASS: &'static str = "cassandra";
+const _ADDR: &'static str = "127.0.0.1:9042";
 
+#[cfg(not(feature = "ssl"))]
 fn main() {
     let config = r2d2::Config::builder()
         .pool_size(15)
         .build();
-    let transport = Transport::new(ADDR).unwrap();
-    let authenticator = PasswordAuthenticator::new(USER, PASS);
+    let transport = Transport::new(_ADDR).unwrap();
+    let authenticator = PasswordAuthenticator::new(_USER, _PASS);
     let manager = ConnectionManager::new(transport, authenticator, Compression::None);
 
     let pool = r2d2::Pool::new(config, manager).unwrap();
@@ -47,4 +53,9 @@ fn main() {
         let res = rx.recv().unwrap();
         println!("{:?}", res);
     }
+}
+
+#[cfg(feature = "ssl")]
+fn main() {
+    unimplemented!()
 }

--- a/examples/create_table.rs
+++ b/examples/create_table.rs
@@ -1,3 +1,5 @@
+// in feature="ssl" imports are unused until examples are implemented
+#![allow(unused_imports, unused_variables)]
 extern crate cdrs;
 
 use cdrs::client::CDRS;
@@ -5,16 +7,20 @@ use cdrs::query::QueryBuilder;
 use cdrs::authenticators::PasswordAuthenticator;
 use cdrs::compression::Compression;
 use cdrs::consistency::Consistency;
+#[cfg(not(feature = "ssl"))]
 use cdrs::transport::Transport;
+#[cfg(feature = "ssl")]
+use cdrs::transport_ssl::Transport;
 
 // default credentials
-const USER: &'static str = "cassandra";
-const PASS: &'static str = "cassandra";
-const ADDR: &'static str = "127.0.0.1:9042";
+const _USER: &'static str = "cassandra";
+const _PASS: &'static str = "cassandra";
+const _ADDR: &'static str = "127.0.0.1:9042";
 
+#[cfg(not(feature = "ssl"))]
 fn main() {
-    let authenticator = PasswordAuthenticator::new(USER, PASS);
-    let tcp_transport = Transport::new(ADDR).unwrap();
+    let authenticator = PasswordAuthenticator::new(_USER, _PASS);
+    let tcp_transport = Transport::new(_ADDR).unwrap();
     let client = CDRS::new(tcp_transport, authenticator);
     let mut session = client.start(Compression::None).unwrap();
 
@@ -37,4 +43,9 @@ fn main() {
         Ok(ref res) => println!("table created: {:?}", res.get_body()),
         Err(ref err) => println!("Error occured: {:?}", err)
     }
+}
+
+#[cfg(feature = "ssl")]
+fn main() {
+    unimplemented!()
 }

--- a/examples/prepare_execute.rs
+++ b/examples/prepare_execute.rs
@@ -1,3 +1,5 @@
+// in feature="ssl" imports are unused until examples are implemented
+#![allow(unused_imports, unused_variables)]
 extern crate cdrs;
 
 use cdrs::client::CDRS;
@@ -5,16 +7,20 @@ use cdrs::query::QueryParamsBuilder;
 use cdrs::authenticators::PasswordAuthenticator;
 use cdrs::compression::Compression;
 use cdrs::consistency::Consistency;
+#[cfg(not(feature = "ssl"))]
 use cdrs::transport::Transport;
+#[cfg(feature = "ssl")]
+use cdrs::transport_ssl::Transport;
 
 // default credentials
-const USER: &'static str = "cassandra";
-const PASS: &'static str = "cassandra";
-const ADDR: &'static str = "127.0.0.1:9042";
+const _USER: &'static str = "cassandra";
+const _PASS: &'static str = "cassandra";
+const _ADDR: &'static str = "127.0.0.1:9042";
 
+#[cfg(not(feature = "ssl"))]
 fn main() {
-    let authenticator = PasswordAuthenticator::new(USER, PASS);
-    let tcp_transport = Transport::new(ADDR).unwrap();
+    let authenticator = PasswordAuthenticator::new(_USER, _PASS);
+    let tcp_transport = Transport::new(_ADDR).unwrap();
     let client = CDRS::new(tcp_transport, authenticator);
     let mut session = client.start(Compression::None).unwrap();
 
@@ -40,4 +46,9 @@ fn main() {
         .unwrap();
 
     println!("executed:\n{:?}", executed);
+}
+
+#[cfg(feature = "ssl")]
+fn main() {
+    unimplemented!()
 }

--- a/examples/read_table_into_struct.rs
+++ b/examples/read_table_into_struct.rs
@@ -1,11 +1,15 @@
-
+// in feature="ssl" imports are unused until examples are implemented
+#![allow(unused_imports, unused_variables)]
 extern crate cdrs;
 use cdrs::client::CDRS;
 use cdrs::query::QueryBuilder;
 use cdrs::authenticators::PasswordAuthenticator;
 use cdrs::compression::Compression;
 use cdrs::types::IntoRustByName;
+#[cfg(not(feature = "ssl"))]
 use cdrs::transport::Transport;
+#[cfg(feature = "ssl")]
+use cdrs::transport_ssl::Transport;
 
 /// this example is to pull employee records from emp table
 ///
@@ -39,6 +43,7 @@ struct Employee {
     pub emp_phone: i64,
 }
 
+#[cfg(not(feature = "ssl"))]
 fn main() {
 
     let authenticator = PasswordAuthenticator::new("user", "pass");
@@ -96,4 +101,9 @@ fn main() {
         Err(err) => println!("{:?}", err),
     }
 
+}
+
+#[cfg(feature = "ssl")]
+fn main() {
+    unimplemented!()
 }

--- a/examples/server_events.rs
+++ b/examples/server_events.rs
@@ -1,22 +1,28 @@
+// in feature="ssl" imports are unused until examples are implemented
+#![allow(unused_imports, unused_variables)]
 extern crate cdrs;
 extern crate r2d2;
 
 use std::thread;
 
 use cdrs::client::CDRS;
-use cdrs::transport::Transport;
 use cdrs::authenticators::PasswordAuthenticator;
 use cdrs::compression::Compression;
 use cdrs::frame::events::SimpleServerEvent;
+#[cfg(not(feature = "ssl"))]
+use cdrs::transport::Transport;
+#[cfg(feature = "ssl")]
+use cdrs::transport_ssl::Transport;
 
 // default credentials
-const USER: &'static str = "cassandra";
-const PASS: &'static str = "cassandra";
-const ADDR: &'static str = "127.0.0.1:9042";
+const _USER: &'static str = "cassandra";
+const _PASS: &'static str = "cassandra";
+const _ADDR: &'static str = "127.0.0.1:9042";
 
+#[cfg(not(feature = "ssl"))]
 fn main() {
-    let transport = Transport::new(ADDR).unwrap();
-    let authenticator = PasswordAuthenticator::new(USER, PASS);
+    let transport = Transport::new(_ADDR).unwrap();
+    let authenticator = PasswordAuthenticator::new(_USER, _PASS);
     let client = CDRS::new(transport, authenticator);
     let session = client.start(Compression::None).unwrap();
 
@@ -31,4 +37,9 @@ fn main() {
     for event in stream {
         println!("server event {:?}", event.get_body());
     }
+}
+
+#[cfg(feature = "ssl")]
+fn main() {
+    unimplemented!()
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,10 +1,15 @@
+// in feature="ssl" imports are unused until examples are implemented
+#![allow(unused_imports, unused_variables)]
 extern crate cdrs;
-use cdrs::client::{CDRS};
+use cdrs::client::CDRS;
 use cdrs::query::QueryBuilder;
 use cdrs::authenticators::NoneAuthenticator;
 use cdrs::compression::Compression;
 use cdrs::types::IntoRustByName;
+#[cfg(not(feature = "ssl"))]
 use cdrs::transport::Transport;
+#[cfg(feature = "ssl")]
+use cdrs::transport_ssl::Transport;
 
 /// this example is to pull employee records from emp table
 ///
@@ -38,6 +43,7 @@ struct Employee {
     pub emp_phone: i64,
 }
 
+#[cfg(not(feature = "ssl"))]
 fn main() {
 
     let addr = "127.0.0.1:9042";
@@ -94,4 +100,9 @@ fn main() {
         Err(err) => println!("{:?}", err),
     }
 
+}
+
+#[cfg(feature = "ssl")]
+fn main() {
+    unimplemented!()
 }

--- a/examples/simple_with_auth.rs
+++ b/examples/simple_with_auth.rs
@@ -1,11 +1,16 @@
-
+// in feature="ssl" imports are unused until examples are implemented
+#![allow(unused_imports, unused_variables)]
 extern crate cdrs;
 use cdrs::client::CDRS;
 use cdrs::query::QueryBuilder;
 use cdrs::authenticators::PasswordAuthenticator;
 use cdrs::compression::Compression;
+#[cfg(not(feature = "ssl"))]
 use cdrs::transport::Transport;
+#[cfg(feature = "ssl")]
+use cdrs::transport_ssl::Transport;
 
+#[cfg(not(feature = "ssl"))]
 fn main() {
 
     let authenticator = PasswordAuthenticator::new("user", "pass");
@@ -39,4 +44,9 @@ fn main() {
     }
 
 
+}
+
+#[cfg(feature = "ssl")]
+fn main() {
+    unimplemented!();
 }


### PR DESCRIPTION
* adopt all examples to not crush when running `cargo test --all-features` or `cargo run --examples example-name --features ssl` (implementations will be provided in next PR)

fixes #63 (1)