### PR TITLE
Use i64 for timestamp

### DIFF
--- a/src/frame/frame_batch.rs
+++ b/src/frame/frame_batch.rs
@@ -15,7 +15,7 @@ pub struct BodyReqBatch {
     /// https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L409
     pub query_flags: Vec<QueryFlags>,
     pub serial_consistency: Option<Consistency>,
-    pub timestamp: Option<i32>,
+    pub timestamp: Option<i64>,
 }
 
 impl IntoBytes for BodyReqBatch {
@@ -45,7 +45,7 @@ impl IntoBytes for BodyReqBatch {
         }
 
         if let Some(ref timestamp) = self.timestamp {
-            bytes.extend_from_slice(to_int(timestamp.clone()).as_slice());
+            bytes.extend_from_slice(to_bigint(timestamp.clone()).as_slice());
         }
 
         bytes

--- a/src/frame/frame_query.rs
+++ b/src/frame/frame_query.rs
@@ -25,7 +25,7 @@ impl BodyReqQuery {
            page_size: Option<i32>,
            paging_state: Option<CBytes>,
            serial_consistency: Option<Consistency>,
-           timestamp: Option<i32>)
+           timestamp: Option<i64>)
            -> BodyReqQuery {
 
         // query flags
@@ -86,7 +86,7 @@ pub struct ParamsReqQuery {
     /// Serial `Consistency`.
     pub serial_consistency: Option<Consistency>,
     /// Timestamp.
-    pub timestamp: Option<i32>,
+    pub timestamp: Option<i64>,
 }
 
 impl ParamsReqQuery {
@@ -153,7 +153,7 @@ impl IntoBytes for ParamsReqQuery {
             v.extend_from_slice(self.serial_consistency.clone().unwrap().into_cbytes().as_slice());
         }
         if QueryFlags::has_with_default_timestamp(self.flags_as_byte()) {
-            v.extend_from_slice(to_int(self.timestamp.unwrap()).as_slice());
+            v.extend_from_slice(to_bigint(self.timestamp.unwrap()).as_slice());
         }
 
         v
@@ -284,7 +284,7 @@ impl Frame {
                              page_size: Option<i32>,
                              paging_state: Option<CBytes>,
                              serial_consistency: Option<Consistency>,
-                             timestamp: Option<i32>,
+                             timestamp: Option<i64>,
                              flags: Vec<Flag>)
                              -> Frame {
         let version = Version::Request;

--- a/src/query.rs
+++ b/src/query.rs
@@ -40,7 +40,7 @@ pub struct Query {
     pub page_size: Option<i32>,
     pub paging_state: Option<CBytes>,
     pub serial_consistency: Option<Consistency>,
-    pub timestamp: Option<i32>,
+    pub timestamp: Option<i64>,
 }
 
 /// QueryBuilder is a helper sturcture that helps to construct `Query`. `Query` itself
@@ -56,7 +56,7 @@ pub struct QueryBuilder {
     page_size: Option<i32>,
     paging_state: Option<CBytes>,
     serial_consistency: Option<Consistency>,
-    timestamp: Option<i32>,
+    timestamp: Option<i64>,
 }
 
 impl QueryBuilder {
@@ -89,7 +89,7 @@ impl QueryBuilder {
     builder_opt_field!(serial_consistency, Consistency);
 
     /// Sets new quey timestamp
-    builder_opt_field!(timestamp, i32);
+    builder_opt_field!(timestamp, i64);
 
     pub fn apply_query_params(mut self, params: QueryParams) -> Self {
         self.consistency = params.consistency;
@@ -128,7 +128,7 @@ pub struct QueryParamsBuilder {
     page_size: Option<i32>,
     paging_state: Option<CBytes>,
     serial_consistency: Option<Consistency>,
-    timestamp: Option<i32>,
+    timestamp: Option<i64>,
 }
 
 impl QueryParamsBuilder {
@@ -174,7 +174,7 @@ impl QueryParamsBuilder {
         return self;
     }
 
-    pub fn timestamp(mut self, timestamp: i32) -> Self {
+    pub fn timestamp(mut self, timestamp: i64) -> Self {
         self.timestamp = Some(timestamp);
 
         return self;
@@ -225,7 +225,7 @@ pub struct BatchQueryBuilder {
     queries: Vec<BatchQuery>,
     consistency: Consistency,
     serial_consistency: Option<Consistency>,
-    timestamp: Option<i32>,
+    timestamp: Option<i64>,
 }
 
 impl BatchQueryBuilder {
@@ -279,7 +279,7 @@ impl BatchQueryBuilder {
         self
     }
 
-    pub fn timestamp(mut self, timestamp: Option<i32>) -> Self {
+    pub fn timestamp(mut self, timestamp: Option<i64>) -> Self {
         self.timestamp = timestamp;
         self
     }

--- a/src/types/data_serialization_types.rs
+++ b/src/types/data_serialization_types.rs
@@ -109,7 +109,7 @@ pub fn decode_inet(bytes: &[u8]) -> Result<net::IpAddr, io::Error> {
     }
 }
 
-// Decodes Cassandra `timestamp` data (bytes) into Rust's `Result<i32, io::Error>`
+// Decodes Cassandra `timestamp` data (bytes) into Rust's `Result<i64, io::Error>`
 // `i32` represets a millisecond-precision
 //  offset from the unix epoch (00:00:00, January 1st, 1970).  Negative values
 //  represent a negative offset from the epoch.


### PR DESCRIPTION
Use i64 for timestamp as referenced in https://github.com/AlexPikalov/cdrs/blob/master/type-mapping.md 