### PR TITLE
Dual license. MIT/Apache-2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/AlexPikalov/cdrs"
 repository = "https://github.com/AlexPikalov/cdrs"
 readme = "./README.md"
 keywords = ["cassandra", "driver", "client", "cassandradb", "DB"]
-license = "MIT"
+license = "MIT/Apache-2.0"
 
 [features]
 default = []


### PR DESCRIPTION
Dual licensing MIT/Apache-2.0
fixes #84 