### PR TITLE
Proper error handling in as_rust! and new macro for IntoRustByName

### DIFF
--- a/src/types/data_serialization_types.rs
+++ b/src/types/data_serialization_types.rs
@@ -326,12 +326,10 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, List) => (
         match $data_type_option.id {
             ColType::List => {
-                List::new(decode_list($data_value.as_slice())?,
-                    $data_type_option.as_ref().clone())
+                List::new(decode_list($data_value.as_slice())?, $data_type_option.clone())
             }
             ColType::Set => {
-                List::new(decode_list($data_value.as_slice())?,
-                    $data_type_option.as_ref().clone())
+                List::new(decode_list($data_value.as_slice())?, $data_type_option.clone())
             }
             _ => return Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into List (valid types: List, Set).",
@@ -341,8 +339,7 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, Map) => (
         match $data_type_option.id {
             ColType::Map => {
-                Map::new(decode_map($data_value.as_slice())?,
-                    $data_type_option.as_ref().clone())
+                Map::new(decode_map($data_value.as_slice())?, $data_type_option.clone())
             }
             _ => return Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into Map (valid types: Map).",

--- a/src/types/data_serialization_types.rs
+++ b/src/types/data_serialization_types.rs
@@ -190,7 +190,9 @@ macro_rules! as_rust {
             ColType::Blob => {
                 decode_blob($data_value.as_plain())?
             }
-            _ => unreachable!()
+            _ => return Err(Error::General(format!("Invalid conversion. \
+                    Cannot convert {:?} into Vec<u8> (valid types: Blob).",
+                    $data_type_option.id)))
         }
     );
     ($data_type_option:ident, $data_value:ident, String) => (
@@ -204,7 +206,13 @@ macro_rules! as_rust {
             ColType::Varchar => {
                 decode_varchar($data_value.as_slice())?
             }
-            _ => unreachable!()
+            // TODO: clarify when to use decode_text.
+            // it's not mentioned in
+            // https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L582
+            // ColType::XXX => decode_text($data_value)?
+            _ => return Err(Error::General(format!("Invalid conversion. \
+                    Cannot convert {:?} into String (valid types: Custom, Ascii, Varchar).",
+                    $data_type_option.id)))
         }
     );
     ($data_type_option:ident, $data_value:ident, bool) => (
@@ -212,7 +220,9 @@ macro_rules! as_rust {
             ColType::Boolean => {
                 decode_boolean($data_value.as_slice())?
             }
-            _ => unreachable!()
+            _ => return Err(Error::General(format!("Invalid conversion. \
+                    Cannot convert {:?} into bool (valid types: Boolean).",
+                    $data_type_option.id)))
         }
     );
     ($data_type_option:ident, $data_value:ident, i64) => (
@@ -229,7 +239,9 @@ macro_rules! as_rust {
             ColType::Varint => {
                 decode_varint($data_value.as_slice())?
             }
-            _ => unreachable!()
+            _ => return Err(Error::General(format!("Invalid conversion. \
+                    Cannot convert {:?} into i64 (valid types: Bigint, Timestamp, Time, Variant).",
+                    $data_type_option.id)))
         }
     );
     ($data_type_option:ident, $data_value:ident, i32) => (
@@ -240,7 +252,9 @@ macro_rules! as_rust {
             ColType::Date => {
                 decode_date($data_value.as_slice())?
             }
-            _ => unreachable!()
+            _ => return Err(Error::General(format!("Invalid conversion. \
+                    Cannot convert {:?} into i32 (valid types: Int, Date).",
+                    $data_type_option.id)))
         }
     );
     ($data_type_option:ident, $data_value:ident, i16) => (
@@ -248,7 +262,9 @@ macro_rules! as_rust {
             ColType::Smallint => {
                 decode_smallint($data_value.as_slice())?
             }
-            _ => unreachable!()
+            _ => return Err(Error::General(format!("Invalid conversion. \
+                    Cannot convert {:?} into i16 (valid types: Smallint).",
+                    $data_type_option.id)))
         }
     );
     ($data_type_option:ident, $data_value:ident, i8) => (
@@ -256,7 +272,9 @@ macro_rules! as_rust {
             ColType::Tinyint => {
                 decode_tinyint($data_value.as_slice())?
             }
-            _ => unreachable!()
+            _ => return Err(Error::General(format!("Invalid conversion. \
+                    Cannot convert {:?} into i8 (valid types: Tinyint).",
+                    $data_type_option.id)))
         }
     );
     ($data_type_option:ident, $data_value:ident, f64) => (
@@ -264,7 +282,9 @@ macro_rules! as_rust {
             ColType::Double => {
                 decode_double($data_value.as_slice())?
             }
-            _ => unreachable!()
+            _ => return Err(Error::General(format!("Invalid conversion. \
+                    Cannot convert {:?} into f64 (valid types: Double).",
+                    $data_type_option.id)))
         }
     );
     ($data_type_option:ident, $data_value:ident, f32) => (
@@ -275,7 +295,9 @@ macro_rules! as_rust {
             ColType::Float => {
                 decode_float($data_value.as_slice())?
             }
-            _ => unreachable!()
+            _ => return Err(Error::General(format!("Invalid conversion. \
+                    Cannot convert {:?} into f32 (valid types: Decimal, Float).",
+                    $data_type_option.id)))
         }
     );
     ($data_type_option:ident, $data_value:ident, IpAddr) => (
@@ -283,7 +305,9 @@ macro_rules! as_rust {
             ColType::Inet => {
                 decode_inet($data_value.as_slice())?
             }
-            _ => unreachable!()
+            _ => return Err(Error::General(format!("Invalid conversion. \
+                    Cannot convert {:?} into IpAddr (valid types: Inet).",
+                    $data_type_option.id)))
         }
     );
     ($data_type_option:ident, $data_value:ident, Uuid) => (
@@ -294,7 +318,9 @@ macro_rules! as_rust {
             ColType::Timeuuid => {
                 decode_timeuuid($data_value.as_slice())?
             }
-            _ => unreachable!()
+            _ => return Err(Error::General(format!("Invalid conversion. \
+                    Cannot convert {:?} into Uuid (valid types: Uuid, Timeuuid).",
+                    $data_type_option.id)))
         }
     );
     ($data_type_option:ident, $data_value:ident, List) => (
@@ -307,7 +333,9 @@ macro_rules! as_rust {
                 List::new(decode_list($data_value.as_slice())?,
                     $data_type_option.as_ref().clone())
             }
-            _ => unreachable!()
+            _ => return Err(Error::General(format!("Invalid conversion. \
+                    Cannot convert {:?} into List (valid types: List, Set).",
+                    $data_type_option.id)))
         }
     );
     ($data_type_option:ident, $data_value:ident, Map) => (
@@ -316,7 +344,9 @@ macro_rules! as_rust {
                 Map::new(decode_map($data_value.as_slice())?,
                     $data_type_option.as_ref().clone())
             }
-            _ => unreachable!()
+            _ => return Err(Error::General(format!("Invalid conversion. \
+                    Cannot convert {:?} into Map (valid types: Map).",
+                    $data_type_option.id)))
         }
     );
     ($data_type_option:ident, $data_value:ident, UDT) => (
@@ -328,7 +358,9 @@ macro_rules! as_rust {
                 UDT::new(decode_udt($data_value.as_slice(), list_type_option.descriptions.len())?,
                     list_type_option)
             }
-            _ => unreachable!()
+            _ => return Err(Error::General(format!("Invalid conversion. \
+                    Cannot convert {:?} into UDT (valid types: UDT).",
+                    $data_type_option.id)))
         }
     );
 }

--- a/src/types/data_serialization_types.rs
+++ b/src/types/data_serialization_types.rs
@@ -188,7 +188,7 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, Vec<u8>) => (
         match $data_type_option.id {
             ColType::Blob => {
-                decode_blob($data_value.as_plain()).unwrap()
+                decode_blob($data_value.as_plain())?
             }
             _ => unreachable!()
         }
@@ -196,13 +196,13 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, String) => (
         match $data_type_option.id {
             ColType::Custom => {
-                decode_custom($data_value.as_slice()).unwrap()
+                decode_custom($data_value.as_slice())?
             }
             ColType::Ascii => {
-                decode_ascii($data_value.as_slice()).unwrap()
+                decode_ascii($data_value.as_slice())?
             }
             ColType::Varchar => {
-                decode_varchar($data_value.as_slice()).unwrap()
+                decode_varchar($data_value.as_slice())?
             }
             _ => unreachable!()
         }
@@ -210,7 +210,7 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, bool) => (
         match $data_type_option.id {
             ColType::Boolean => {
-                decode_boolean($data_value.as_slice()).unwrap()
+                decode_boolean($data_value.as_slice())?
             }
             _ => unreachable!()
         }
@@ -218,16 +218,16 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, i64) => (
         match $data_type_option.id {
             ColType::Bigint => {
-                decode_bigint($data_value.as_slice()).unwrap()
+                decode_bigint($data_value.as_slice())?
             }
             ColType::Timestamp => {
-                decode_timestamp($data_value.as_slice()).unwrap()
+                decode_timestamp($data_value.as_slice())?
             }
             ColType::Time => {
-                decode_time($data_value.as_slice()).unwrap()
+                decode_time($data_value.as_slice())?
             }
             ColType::Varint => {
-                decode_varint($data_value.as_slice()).unwrap()
+                decode_varint($data_value.as_slice())?
             }
             _ => unreachable!()
         }
@@ -235,10 +235,10 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, i32) => (
         match $data_type_option.id {
             ColType::Int => {
-                decode_int($data_value.as_slice()).unwrap()
+                decode_int($data_value.as_slice())?
             }
             ColType::Date => {
-                decode_date($data_value.as_slice()).unwrap()
+                decode_date($data_value.as_slice())?
             }
             _ => unreachable!()
         }
@@ -246,7 +246,7 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, i16) => (
         match $data_type_option.id {
             ColType::Smallint => {
-                decode_smallint($data_value.as_slice()).unwrap()
+                decode_smallint($data_value.as_slice())?
             }
             _ => unreachable!()
         }
@@ -254,7 +254,7 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, i8) => (
         match $data_type_option.id {
             ColType::Tinyint => {
-                decode_tinyint($data_value.as_slice()).unwrap()
+                decode_tinyint($data_value.as_slice())?
             }
             _ => unreachable!()
         }
@@ -262,7 +262,7 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, f64) => (
         match $data_type_option.id {
             ColType::Double => {
-                decode_double($data_value.as_slice()).unwrap()
+                decode_double($data_value.as_slice())?
             }
             _ => unreachable!()
         }
@@ -270,10 +270,10 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, f32) => (
         match $data_type_option.id {
             ColType::Decimal => {
-                decode_decimal($data_value.as_slice()).unwrap()
+                decode_decimal($data_value.as_slice())?
             }
             ColType::Float => {
-                decode_float($data_value.as_slice()).unwrap()
+                decode_float($data_value.as_slice())?
             }
             _ => unreachable!()
         }
@@ -281,7 +281,7 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, IpAddr) => (
         match $data_type_option.id {
             ColType::Inet => {
-                decode_inet($data_value.as_slice()).unwrap()
+                decode_inet($data_value.as_slice())?
             }
             _ => unreachable!()
         }
@@ -289,10 +289,10 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, Uuid) => (
         match $data_type_option.id {
             ColType::Uuid => {
-                decode_timeuuid($data_value.as_slice()).unwrap()
+                decode_timeuuid($data_value.as_slice())?
             }
             ColType::Timeuuid => {
-                decode_timeuuid($data_value.as_slice()).unwrap()
+                decode_timeuuid($data_value.as_slice())?
             }
             _ => unreachable!()
         }
@@ -300,11 +300,11 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, List) => (
         match $data_type_option.id {
             ColType::List => {
-                List::new(decode_list($data_value.as_slice()).unwrap(),
+                List::new(decode_list($data_value.as_slice())?,
                     $data_type_option.as_ref().clone())
             }
             ColType::Set => {
-                List::new(decode_list($data_value.as_slice()).unwrap(),
+                List::new(decode_list($data_value.as_slice())?,
                     $data_type_option.as_ref().clone())
             }
             _ => unreachable!()
@@ -313,7 +313,7 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, Map) => (
         match $data_type_option.id {
             ColType::Map => {
-                Map::new(decode_map($data_value.as_slice()).unwrap(),
+                Map::new(decode_map($data_value.as_slice())?,
                     $data_type_option.as_ref().clone())
             }
             _ => unreachable!()
@@ -325,8 +325,8 @@ macro_rules! as_rust {
                 id: ColType::Udt,
                 value: Some(ColTypeOptionValue::UdtType(ref list_type_option))
             } => {
-                UDT::new(decode_udt($data_value.as_slice(),
-                    list_type_option.descriptions.len()).unwrap(), list_type_option)
+                UDT::new(decode_udt($data_value.as_slice(), list_type_option.descriptions.len())?,
+                    list_type_option)
             }
             _ => unreachable!()
         }

--- a/src/types/data_serialization_types.rs
+++ b/src/types/data_serialization_types.rs
@@ -188,9 +188,10 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, Vec<u8>) => (
         match $data_type_option.id {
             ColType::Blob => {
-                decode_blob($data_value.as_plain())?
+                decode_blob($data_value.as_plain())
+                    .map_err(Into::into)
             }
-            _ => return Err(Error::General(format!("Invalid conversion. \
+            _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into Vec<u8> (valid types: Blob).",
                     $data_type_option.id)))
         }
@@ -198,19 +199,22 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, String) => (
         match $data_type_option.id {
             ColType::Custom => {
-                decode_custom($data_value.as_slice())?
+                decode_custom($data_value.as_slice())
+                    .map_err(Into::into)
             }
             ColType::Ascii => {
-                decode_ascii($data_value.as_slice())?
+                decode_ascii($data_value.as_slice())
+                    .map_err(Into::into)
             }
             ColType::Varchar => {
-                decode_varchar($data_value.as_slice())?
+                decode_varchar($data_value.as_slice())
+                    .map_err(Into::into)
             }
             // TODO: clarify when to use decode_text.
             // it's not mentioned in
             // https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L582
             // ColType::XXX => decode_text($data_value)?
-            _ => return Err(Error::General(format!("Invalid conversion. \
+            _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into String (valid types: Custom, Ascii, Varchar).",
                     $data_type_option.id)))
         }
@@ -218,9 +222,10 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, bool) => (
         match $data_type_option.id {
             ColType::Boolean => {
-                decode_boolean($data_value.as_slice())?
+                decode_boolean($data_value.as_slice())
+                    .map_err(Into::into)
             }
-            _ => return Err(Error::General(format!("Invalid conversion. \
+            _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into bool (valid types: Boolean).",
                     $data_type_option.id)))
         }
@@ -228,18 +233,22 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, i64) => (
         match $data_type_option.id {
             ColType::Bigint => {
-                decode_bigint($data_value.as_slice())?
+                decode_bigint($data_value.as_slice())
+                    .map_err(Into::into)
             }
             ColType::Timestamp => {
-                decode_timestamp($data_value.as_slice())?
+                decode_timestamp($data_value.as_slice())
+                    .map_err(Into::into)
             }
             ColType::Time => {
-                decode_time($data_value.as_slice())?
+                decode_time($data_value.as_slice())
+                    .map_err(Into::into)
             }
             ColType::Varint => {
-                decode_varint($data_value.as_slice())?
+                decode_varint($data_value.as_slice())
+                    .map_err(Into::into)
             }
-            _ => return Err(Error::General(format!("Invalid conversion. \
+            _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into i64 (valid types: Bigint, Timestamp, Time, Variant).",
                     $data_type_option.id)))
         }
@@ -247,12 +256,14 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, i32) => (
         match $data_type_option.id {
             ColType::Int => {
-                decode_int($data_value.as_slice())?
+                decode_int($data_value.as_slice())
+                    .map_err(Into::into)
             }
             ColType::Date => {
-                decode_date($data_value.as_slice())?
+                decode_date($data_value.as_slice())
+                    .map_err(Into::into)
             }
-            _ => return Err(Error::General(format!("Invalid conversion. \
+            _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into i32 (valid types: Int, Date).",
                     $data_type_option.id)))
         }
@@ -260,9 +271,10 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, i16) => (
         match $data_type_option.id {
             ColType::Smallint => {
-                decode_smallint($data_value.as_slice())?
+                decode_smallint($data_value.as_slice())
+                    .map_err(Into::into)
             }
-            _ => return Err(Error::General(format!("Invalid conversion. \
+            _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into i16 (valid types: Smallint).",
                     $data_type_option.id)))
         }
@@ -270,9 +282,10 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, i8) => (
         match $data_type_option.id {
             ColType::Tinyint => {
-                decode_tinyint($data_value.as_slice())?
+                decode_tinyint($data_value.as_slice())
+                    .map_err(Into::into)
             }
-            _ => return Err(Error::General(format!("Invalid conversion. \
+            _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into i8 (valid types: Tinyint).",
                     $data_type_option.id)))
         }
@@ -280,9 +293,10 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, f64) => (
         match $data_type_option.id {
             ColType::Double => {
-                decode_double($data_value.as_slice())?
+                decode_double($data_value.as_slice())
+                    .map_err(Into::into)
             }
-            _ => return Err(Error::General(format!("Invalid conversion. \
+            _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into f64 (valid types: Double).",
                     $data_type_option.id)))
         }
@@ -290,12 +304,14 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, f32) => (
         match $data_type_option.id {
             ColType::Decimal => {
-                decode_decimal($data_value.as_slice())?
+                decode_decimal($data_value.as_slice())
+                    .map_err(Into::into)
             }
             ColType::Float => {
-                decode_float($data_value.as_slice())?
+                decode_float($data_value.as_slice())
+                    .map_err(Into::into)
             }
-            _ => return Err(Error::General(format!("Invalid conversion. \
+            _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into f32 (valid types: Decimal, Float).",
                     $data_type_option.id)))
         }
@@ -303,35 +319,35 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, IpAddr) => (
         match $data_type_option.id {
             ColType::Inet => {
-                decode_inet($data_value.as_slice())?
+                decode_inet($data_value.as_slice())
+                    .map_err(Into::into)
             }
-            _ => return Err(Error::General(format!("Invalid conversion. \
+            _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into IpAddr (valid types: Inet).",
                     $data_type_option.id)))
         }
     );
     ($data_type_option:ident, $data_value:ident, Uuid) => (
         match $data_type_option.id {
-            ColType::Uuid => {
-                decode_timeuuid($data_value.as_slice())?
-            }
+            ColType::Uuid |
             ColType::Timeuuid => {
-                decode_timeuuid($data_value.as_slice())?
+                decode_timeuuid($data_value.as_slice())
+                    .map_err(Into::into)
             }
-            _ => return Err(Error::General(format!("Invalid conversion. \
+            _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into Uuid (valid types: Uuid, Timeuuid).",
                     $data_type_option.id)))
         }
     );
     ($data_type_option:ident, $data_value:ident, List) => (
         match $data_type_option.id {
-            ColType::List => {
-                List::new(decode_list($data_value.as_slice())?, $data_type_option.clone())
-            }
+            ColType::List |
             ColType::Set => {
-                List::new(decode_list($data_value.as_slice())?, $data_type_option.clone())
+                decode_list($data_value.as_slice())
+                    .map(|data| List::new(data, $data_type_option.clone()))
+                    .map_err(Into::into)
             }
-            _ => return Err(Error::General(format!("Invalid conversion. \
+            _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into List (valid types: List, Set).",
                     $data_type_option.id)))
         }
@@ -339,9 +355,11 @@ macro_rules! as_rust {
     ($data_type_option:ident, $data_value:ident, Map) => (
         match $data_type_option.id {
             ColType::Map => {
-                Map::new(decode_map($data_value.as_slice())?, $data_type_option.clone())
+                decode_map($data_value.as_slice())
+                    .map(|data| Map::new(data, $data_type_option.clone()))
+                    .map_err(Into::into)
             }
-            _ => return Err(Error::General(format!("Invalid conversion. \
+            _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into Map (valid types: Map).",
                     $data_type_option.id)))
         }
@@ -352,10 +370,11 @@ macro_rules! as_rust {
                 id: ColType::Udt,
                 value: Some(ColTypeOptionValue::UdtType(ref list_type_option))
             } => {
-                UDT::new(decode_udt($data_value.as_slice(), list_type_option.descriptions.len())?,
-                    list_type_option)
+                decode_udt($data_value.as_slice(), list_type_option.descriptions.len())
+                    .map(|data| UDT::new(data, list_type_option))
+                    .map_err(Into::into)
             }
-            _ => return Err(Error::General(format!("Invalid conversion. \
+            _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into UDT (valid types: UDT).",
                     $data_type_option.id)))
         }

--- a/src/types/map.rs
+++ b/src/types/map.rs
@@ -37,8 +37,8 @@ macro_rules! map_as_rust {
                         for &(ref key, ref val) in self.data.iter() {
                             let key_type_option = key_type_option.as_ref();
                             let val_type_option = val_type_option.as_ref();
-                            let key = as_rust!(key_type_option, key, $($key_type)*);
-                            let val = as_rust!(val_type_option, val, $($val_type)*);
+                            let key = as_rust!(key_type_option, key, $($key_type)*)?;
+                            let val = as_rust!(val_type_option, val, $($val_type)*)?;
                             map.insert(key, val);
                         }
 

--- a/src/types/map.rs
+++ b/src/types/map.rs
@@ -7,7 +7,7 @@ use frame::frame_result::{ColTypeOption, ColTypeOptionValue, ColType};
 use types::data_serialization_types::*;
 use types::list::List;
 use types::udt::UDT;
-use error::Result;
+use error::{Error, Result};
 
 #[derive(Debug)]
 pub struct Map {

--- a/src/types/map.rs
+++ b/src/types/map.rs
@@ -35,8 +35,8 @@ macro_rules! map_as_rust {
                         let mut map = HashMap::with_capacity(self.data.len());
 
                         for &(ref key, ref val) in self.data.iter() {
-                            let key_type_option = key_type_option.clone();
-                            let val_type_option = val_type_option.clone();
+                            let key_type_option = key_type_option.as_ref();
+                            let val_type_option = val_type_option.as_ref();
                             let key = as_rust!(key_type_option, key, $($key_type)*);
                             let val = as_rust!(val_type_option, val, $($val_type)*);
                             map.insert(key, val);

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -354,6 +354,9 @@ impl CBytes {
     pub fn as_slice(&self) -> &[u8] {
         self.bytes.as_slice()
     }
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
 }
 
 impl FromCursor for CBytes {

--- a/src/types/rows.rs
+++ b/src/types/rows.rs
@@ -1,14 +1,14 @@
-use std::net;
+use std::net::IpAddr;
 use uuid::Uuid;
 
-use frame::frame_result::{RowsMetadata, ColType, ColSpec, BodyResResultRows, ColTypeOptionValue};
+use frame::frame_result::{RowsMetadata, ColType, ColSpec, BodyResResultRows, ColTypeOption,
+                          ColTypeOptionValue};
 use types::{CBytes, IntoRustByName};
 use types::data_serialization_types::*;
 use types::list::List;
 use types::map::Map;
 use types::udt::UDT;
-use error::{Result, column_is_empty_err};
-use std::io;
+use error::{Error, Result, column_is_empty_err};
 
 #[derive(Debug)]
 pub struct Row {
@@ -18,7 +18,7 @@ pub struct Row {
 
 impl Row {
     pub fn from_frame_body(body: BodyResResultRows) -> Vec<Row> {
-        return body.rows_content
+        body.rows_content
             .iter()
             .map(|row| {
                 Row {
@@ -26,366 +26,60 @@ impl Row {
                     row_content: row.clone(),
                 }
             })
-            .collect();
-    }
-
-    fn get_col_by_name(&self, name: &str) -> Option<(&ColType, &CBytes)> {
-        let i_opt = self.metadata.col_specs.iter().position(|spec| spec.name.as_str() == name);
-        if !i_opt.is_some() {
-            return None;
-        }
-        let i = i_opt.unwrap();
-        let ref data: CBytes = self.row_content[i];
-        let ref cassandra_type: ColType = self.metadata.col_specs[i].col_type.id;
-        return Some((cassandra_type, data));
+            .collect()
     }
 
     fn get_col_spec_by_name(&self, name: &str) -> Option<(&ColSpec, &CBytes)> {
-        let i_opt = self.metadata.col_specs.iter().position(|spec| spec.name.as_str() == name);
-        if !i_opt.is_some() {
-            return None;
-        }
-        let i = i_opt.unwrap();
-        let ref data: CBytes = self.row_content[i];
-        let ref cassandra_type: ColSpec = self.metadata.col_specs[i];
-        return Some((cassandra_type, data));
+        self.metadata
+            .col_specs
+            .iter()
+            .position(|spec| spec.name.as_str() == name)
+            .map(|i| {
+                let ref col_spec = self.metadata.col_specs[i];
+                let ref data = self.row_content[i];
+                (col_spec, data)
+            })
     }
 }
 
 impl IntoRustByName<Vec<u8>> for Row {
     fn get_by_name(&self, name: &str) -> Option<Result<Vec<u8>>> {
-        return self.get_col_by_name(name).map(|(cassandra_type, cbytes)| {
-            let bytes = cbytes.as_plain();
-            let converted = match cassandra_type {
-                &ColType::Blob => decode_blob(bytes),
-                _ => unreachable!(),
-            };
-            return converted.map_err(|err| err.into());
-        });
+        self.get_col_spec_by_name(name)
+            .map(|(col_spec, cbytes)| {
+                let ref col_type = col_spec.col_type;
+                Ok(as_rust!(col_type, cbytes, Vec<u8>))
+            })
     }
 }
 
-impl IntoRustByName<String> for Row {
-    fn get_by_name(&self, name: &str) -> Option<Result<String>> {
-        return self.get_col_by_name(name).map(|(cassandra_type, cbytes)| {
-            let bytes = cbytes.as_plain();
+macro_rules! row_into_rust_by_name {
+    ($($into_type:tt)*) => (
+        impl IntoRustByName<$($into_type)*> for Row {
+            fn get_by_name(&self, name: &str) -> Option<Result<$($into_type)*>> {
+                self.get_col_spec_by_name(name)
+                    .map(|(col_spec, cbytes)| {
+                        if cbytes.is_empty() {
+                            return Err(column_is_empty_err());
+                        }
 
-            if bytes.is_empty() {
-                return Err(column_is_empty_err());
+                        let ref col_type = col_spec.col_type;
+                        Ok(as_rust!(col_type, cbytes, $($into_type)*))
+                    })
             }
-
-            let converted = match cassandra_type {
-                &ColType::Custom => decode_custom(bytes.as_slice()),
-                &ColType::Ascii => decode_ascii(bytes.as_slice()),
-                &ColType::Varchar => decode_varchar(bytes.as_slice()),
-                // TODO: clarify when to use decode_text.
-                // it's not mentioned in
-                // https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L582
-                // &ColType::XXX => decode_text(bytes).ok(),
-                _ => unreachable!(),
-            };
-
-            return converted.map_err(|err| err.into());
-        });
-    }
+        }
+    );
 }
 
-impl IntoRustByName<bool> for Row {
-    fn get_by_name(&self, name: &str) -> Option<Result<bool>> {
-        return self.get_col_by_name(name).map(|(cassandra_type, cbytes)| {
-            let bytes = cbytes.as_slice();
-
-            if bytes.is_empty() {
-                return Err(column_is_empty_err());
-            }
-
-            let converted = match cassandra_type {
-                &ColType::Boolean => decode_boolean(bytes),
-                _ => {
-                    let io_err =
-                        io::Error::new(io::ErrorKind::NotFound,
-                                       format!("Unsupported type of converter. {:?} got, but
-                    (bool ) is only supported.",
-                                               cassandra_type));
-                    Err(io_err)
-                }
-            };
-
-            return converted.map_err(|err| err.into());
-        });
-    }
-}
-
-impl IntoRustByName<i64> for Row {
-    fn get_by_name(&self, name: &str) -> Option<Result<i64>> {
-        return self.get_col_by_name(name).map(|(cassandra_type, cbytes)| {
-            let bytes = cbytes.as_slice();
-
-            if bytes.is_empty() {
-                return Err(column_is_empty_err());
-            }
-
-            let converted = match cassandra_type {
-                &ColType::Int => decode_bigint(bytes),
-                &ColType::Bigint => decode_bigint(bytes),
-                &ColType::Timestamp => decode_timestamp(bytes),
-                &ColType::Time => decode_time(bytes),
-                &ColType::Varint => decode_varint(bytes),
-                &ColType::Float => decode_varint(bytes),
-                _ => {
-                    let io_err =
-                        io::Error::new(io::ErrorKind::NotFound,
-                                       format!("Unsupported type of converter. {:?} got, but
-                    (Int,Bigint,Timestamp,Time,Varint,Float ) is only supported.",
-                                               cassandra_type));
-                    Err(io_err)
-                }
-            };
-
-            return converted.map_err(|err| err.into());
-        });
-    }
-}
-
-impl IntoRustByName<i32> for Row {
-    fn get_by_name(&self, name: &str) -> Option<Result<i32>> {
-        return self.get_col_by_name(name).map(|(cassandra_type, cbytes)| {
-            let bytes = cbytes.as_slice();
-
-            if bytes.is_empty() {
-                return Err(column_is_empty_err());
-            }
-
-            let converted = match cassandra_type {
-                &ColType::Int => decode_int(bytes),
-                &ColType::Date => decode_date(bytes),
-                _ => {
-                    let io_err =
-                        io::Error::new(io::ErrorKind::NotFound,
-                                       format!("Unsupported type of converter. {:?} got, but
-                    (Int,date ) is only supported.",
-                                               cassandra_type));
-                    Err(io_err)
-                }
-            };
-
-            return converted.map_err(|err| err.into());
-        });
-    }
-}
-
-impl IntoRustByName<i16> for Row {
-    fn get_by_name(&self, name: &str) -> Option<Result<i16>> {
-        return self.get_col_by_name(name).map(|(cassandra_type, cbytes)| {
-            let bytes = cbytes.as_slice();
-
-            if bytes.is_empty() {
-                return Err(column_is_empty_err());
-            }
-
-            let converted = match cassandra_type {
-                &ColType::Smallint => decode_smallint(bytes),
-                _ => {
-                    let io_err =
-                        io::Error::new(io::ErrorKind::NotFound,
-                                       format!("Unsupported type of converter. {:?} got, but
-                    (Smallint) is only supported.",
-                                               cassandra_type));
-                    Err(io_err)
-                }
-            };
-            return converted.map_err(|err| err.into());
-        });
-    }
-}
-
-impl IntoRustByName<i8> for Row {
-    fn get_by_name(&self, name: &str) -> Option<Result<i8>> {
-        return self.get_col_by_name(name).map(|(cassandra_type, cbytes)| {
-            let bytes = cbytes.as_slice();
-
-            if bytes.is_empty() {
-                return Err(column_is_empty_err());
-            }
-
-            let converted = match cassandra_type {
-                &ColType::Tinyint => decode_tinyint(bytes),
-                _ => {
-                    let io_err =
-                        io::Error::new(io::ErrorKind::NotFound,
-                                       format!("Unsupported type of converter. {:?} got, but
-                    (Tinyint) is only supported.",
-                                               cassandra_type));
-                    Err(io_err)
-                }
-            };
-            return converted.map_err(|err| err.into());
-        });
-    }
-}
-
-impl IntoRustByName<f64> for Row {
-    fn get_by_name(&self, name: &str) -> Option<Result<f64>> {
-        return self.get_col_by_name(name).map(|(cassandra_type, cbytes)| {
-            let bytes = cbytes.as_slice();
-
-            if bytes.is_empty() {
-                return Err(column_is_empty_err());
-            }
-
-            let converted = match cassandra_type {
-                &ColType::Double => decode_double(bytes),
-                _ => {
-                    let io_err =
-                        io::Error::new(io::ErrorKind::NotFound,
-                                       format!("Unsupported type of converter. {:?} got, but
-                    (Double) is only supported.",
-                                               cassandra_type));
-                    Err(io_err)
-                }
-            };
-
-            return converted.map_err(|err| err.into());
-        });
-    }
-}
-
-impl IntoRustByName<f32> for Row {
-    fn get_by_name(&self, name: &str) -> Option<Result<f32>> {
-        return self.get_col_by_name(name).map(|(cassandra_type, cbytes)| {
-            let bytes = cbytes.as_slice();
-
-            if bytes.is_empty() {
-                return Err(column_is_empty_err());
-            }
-
-            let converted = match cassandra_type {
-                &ColType::Decimal => decode_decimal(bytes),
-                &ColType::Float => decode_float(bytes),
-                _ => {
-                    let io_err =
-                        io::Error::new(io::ErrorKind::NotFound,
-                                       format!("Unsupported type of converter. {:?} got, but
-                    (Float,Decimal) is only supported.",
-                                               cassandra_type));
-                    Err(io_err)
-                }
-            };
-
-            return converted.map_err(|err| err.into());
-        });
-    }
-}
-
-impl IntoRustByName<net::IpAddr> for Row {
-    fn get_by_name(&self, name: &str) -> Option<Result<net::IpAddr>> {
-        return self.get_col_by_name(name).map(|(cassandra_type, cbytes)| {
-            let bytes = cbytes.as_slice();
-
-            if bytes.is_empty() {
-                return Err(column_is_empty_err());
-            }
-
-            let converted = match cassandra_type {
-                &ColType::Inet => decode_inet(bytes),
-                _ => {
-                    let io_err =
-                        io::Error::new(io::ErrorKind::NotFound,
-                                       format!("Unsupported type of converter. {:?} got, but
-                    (Inet) is only supported.",
-                                               cassandra_type));
-                    Err(io_err)
-                }
-            };
-
-            return converted.map_err(|err| err.into());
-        });
-    }
-}
-
-impl IntoRustByName<Uuid> for Row {
-    fn get_by_name(&self, name: &str) -> Option<Result<Uuid>> {
-        return self.get_col_by_name(name).map(|(cassandra_type, cbytes)| {
-            let bytes = cbytes.as_slice();
-
-            if bytes.is_empty() {
-                return Err(column_is_empty_err());
-            }
-
-            let converted = match cassandra_type {
-                &ColType::Uuid => decode_timeuuid(bytes),
-                &ColType::Timeuuid => decode_timeuuid(bytes),
-                _ => unreachable!(),
-            };
-
-            return converted.map_err(|err| err.into());
-        });
-    }
-}
-
-impl IntoRustByName<List> for Row {
-    fn get_by_name(&self, name: &str) -> Option<Result<List>> {
-        return self.get_col_spec_by_name(name).map(|(cassandra_type, cbytes)| {
-            let bytes = cbytes.as_slice();
-
-            if bytes.is_empty() {
-                return Err(column_is_empty_err());
-            }
-
-            return match cassandra_type.col_type.id {
-                // in fact, both decode_list and decode_set return Ok
-                ColType::List => {
-                    Ok(List::new(decode_list(bytes).unwrap(), cassandra_type.col_type.clone()))
-                }
-                ColType::Set => {
-                    Ok(List::new(decode_set(bytes).unwrap(), cassandra_type.col_type.clone()))
-                }
-                _ => unreachable!(),
-            };
-        });
-    }
-}
-
-impl IntoRustByName<Map> for Row {
-    fn get_by_name(&self, name: &str) -> Option<Result<Map>> {
-        return self.get_col_spec_by_name(name).map(|(cassandra_type, cbytes)| {
-            let bytes = cbytes.as_slice();
-
-            if bytes.is_empty() {
-                return Err(column_is_empty_err());
-            }
-
-            return match cassandra_type.col_type.id {
-                // in fact, both decode_map and decode_set return Ok
-                ColType::Map => {
-                    Ok(Map::new(decode_map(bytes).unwrap(), cassandra_type.col_type.clone()))
-                }
-                _ => unreachable!(),
-            };
-        });
-    }
-}
-
-impl IntoRustByName<UDT> for Row {
-    fn get_by_name(&self, name: &str) -> Option<Result<UDT>> {
-        return self.get_col_spec_by_name(name).map(|(cassandra_type, cbytes)| {
-            let bytes = cbytes.as_slice();
-
-            if bytes.is_empty() {
-                return Err(column_is_empty_err());
-            }
-
-            let cudt = match cassandra_type.col_type.value {
-                Some(ColTypeOptionValue::UdtType(ref t)) => t,
-                _ => unreachable!(),
-            };
-
-            return match cassandra_type.col_type.id {
-                ColType::Udt => {
-                    Ok(UDT::new(decode_udt(bytes, cudt.descriptions.len()).unwrap(), cudt))
-                }
-                _ => unreachable!(),
-            };
-        });
-    }
-}
+row_into_rust_by_name!(String);
+row_into_rust_by_name!(bool);
+row_into_rust_by_name!(i64);
+row_into_rust_by_name!(i32);
+row_into_rust_by_name!(i16);
+row_into_rust_by_name!(i8);
+row_into_rust_by_name!(f64);
+row_into_rust_by_name!(f32);
+row_into_rust_by_name!(IpAddr);
+row_into_rust_by_name!(Uuid);
+row_into_rust_by_name!(List);
+row_into_rust_by_name!(Map);
+row_into_rust_by_name!(UDT);

--- a/src/types/rows.rs
+++ b/src/types/rows.rs
@@ -47,7 +47,7 @@ impl IntoRustByName<Vec<u8>> for Row {
         self.get_col_spec_by_name(name)
             .map(|(col_spec, cbytes)| {
                 let ref col_type = col_spec.col_type;
-                Ok(as_rust!(col_type, cbytes, Vec<u8>))
+                as_rust!(col_type, cbytes, Vec<u8>)
             })
     }
 }
@@ -63,7 +63,7 @@ macro_rules! row_into_rust_by_name {
                         }
 
                         let ref col_type = col_spec.col_type;
-                        Ok(as_rust!(col_type, cbytes, $($into_type)*))
+                        as_rust!(col_type, cbytes, $($into_type)*)
                     })
             }
         }


### PR DESCRIPTION
1.  "Return" `Result`s from `as_rust!` instead of using `unwrap()` and `unreachable!`.

2. Implement `IntoRustByName<_> for Row` using a new macro `row_into_rust_by_name!`.
`row_into_rust_by_name!` uses `as_rust!` and the implementations change a bit, although I think the new behavior is more accurate.
But it still leaves a problem. `get_by_name()` returns `Option<Result<_>>`. `None` if the column can't be found and `Some(Err(_))` if the conversion fails. It also returns a custom error if the value is empty (except for blobs) and it doesn't handle `null` values explicitly. It would be nice if an `Option` could be returned, that is `None` in case of a `null` value.
Maybe we could change the return type to `Result<Option<_>>` and return an error if the column can't be found. I'm not sure what the use case for the current implementation is, is it a common use case to look for a column that might not be there?