### PR TITLE
Transport timeouts

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -2,12 +2,25 @@ use std::io;
 use std::io::{Read, Write};
 use std::net;
 use std::net::TcpStream;
+use std::time::Duration;
 #[cfg(feature = "ssl")]
 use openssl::ssl::{SslStream, SslConnector};
 
 pub trait CDRSTransport: Sized + Read + Write + Send + Sync {
+    /// Creates a new independently owned handle to the underlying socket.
+    ///
+    /// The returned TcpStream is a reference to the same stream that this object references.
+    /// Both handles will read and write the same stream of data, and options set on one stream
+    /// will be propagated to the other stream.
     fn try_clone(&self) -> io::Result<Self>;
+
+    /// Shuts down the read, write, or both halves of this connection.
     fn close(&mut self, close: net::Shutdown) -> io::Result<()>;
+
+    /// Method which set given duration both as read and write timeout.
+    /// If the value specified is None, then read() calls will block indefinitely.
+    /// It is an error to pass the zero Duration to this method.
+    fn set_timeout(&mut self, dur: Option<Duration>) -> io::Result<()>;
 }
 
 pub struct TransportTcp {
@@ -19,7 +32,7 @@ impl TransportTcp {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use cdrs::transport::TransportTcp;
     /// let addr = "127.0.0.1:9042";
     /// let tcp_transport = TransportTcp::new(addr).unwrap();
@@ -53,6 +66,10 @@ impl CDRSTransport for TransportTcp {
 
     fn close(&mut self, close: net::Shutdown) -> io::Result<()> {
         self.tcp.shutdown(close)
+    }
+
+    fn set_timeout(&mut self, dur: Option<Duration>) -> io::Result<()> {
+        self.tcp.set_read_timeout(dur).and_then(|_| self.tcp.set_write_timeout(dur))
     }
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -150,4 +150,9 @@ impl CDRSTransport for TransportTls {
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
             .and_then(|_| Ok(()))
     }
+
+    fn set_timeout(&mut self, dur: Option<Duration>) -> io::Result<()> {
+        let stream = self.ssl.get_mut();
+        stream.set_read_timeout(dur).and_then(|_| stream.set_write_timeout(dur))
+    }
 }

--- a/src/types/data_serialization_types.rs
+++ b/src/types/data_serialization_types.rs
@@ -418,10 +418,6 @@ mod tests {
     use std::net::IpAddr;
     use super::*;
     use super::super::super::frame::frame_result::*;
-    use super::super::super::*;
-    use super::super::*;
-    use super::super::list::*;
-    use super::super::map::*;
     use super::super::super::error::*;
 
     #[test]


### PR DESCRIPTION
* add method `set_timeout` to `CDRSTransport` trait
* implement `set_timeout` method for `TransportTcp`
* implement `set_timeout` method for `TransportTls`