### PR TITLE
Support timestamps using time::Timespec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ lz4-compress = "0.1.0"
 r2d2 = "0.7.1"
 openssl = { version = "0.9.6", optional = true }
 rand = "0.3"
+time = "0.1.36"
 
 [dev-dependencies]
 env_logger = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ extern crate uuid;
 extern crate openssl;
 extern crate r2d2;
 extern crate rand;
+extern crate time;
 
 use std::io::Cursor;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -312,4 +312,16 @@ macro_rules! as_rust {
                     $data_type_option.id)))
         }
     );
+    ($data_type_option:ident, $data_value:ident, Timespec) => (
+        match $data_type_option.id {
+            ColType::Timestamp => {
+                decode_timestamp($data_value.as_slice())
+                    .map(|ts| Timespec::new(ts / 1_000, (ts % 1_000 * 1_000_000) as i32))
+                    .map_err(Into::into)
+            }
+            _ => Err(Error::General(format!("Invalid conversion. \
+                    Cannot convert {:?} into Timespec (valid types: Timestamp).",
+                    $data_type_option.id)))
+        }
+    );
 }

--- a/src/types/rows.rs
+++ b/src/types/rows.rs
@@ -1,5 +1,6 @@
 use std::net::IpAddr;
 use uuid::Uuid;
+use time::Timespec;
 
 use frame::frame_result::{RowsMetadata, ColType, ColSpec, BodyResResultRows, ColTypeOption,
                           ColTypeOptionValue};
@@ -65,3 +66,4 @@ into_rust_by_name!(Row, Uuid);
 into_rust_by_name!(Row, List);
 into_rust_by_name!(Row, Map);
 into_rust_by_name!(Row, UDT);
+into_rust_by_name!(Row, Timespec);

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use uuid::Uuid;
+use time::Timespec;
 use IntoBytes;
 use super::*;
 use std::convert::Into;
@@ -177,6 +178,13 @@ impl Into<Bytes> for f32 {
 impl Into<Bytes> for f64 {
     fn into(self) -> Bytes {
         Bytes(to_float_big(self))
+    }
+}
+
+impl Into<Bytes> for Timespec {
+    fn into(self) -> Bytes {
+        let ts: i64 = self.sec * 1_000 + self.nsec as i64 / 1_000_000;
+        Bytes(to_bigint(ts))
     }
 }
 

--- a/tests/crud_operations.rs
+++ b/tests/crud_operations.rs
@@ -1,6 +1,7 @@
 // TODO: add update and delete operations
 extern crate cdrs;
 extern crate uuid;
+extern crate time;
 
 use uuid::Uuid;
 use std::convert::Into;
@@ -71,6 +72,11 @@ const CREATE_TABLE_BLOB: &'static str = "CREATE TABLE IF NOT EXISTS my_ks.blob (
 const INSERT_BLOB: &'static str = "INSERT INTO my_ks.blob (my_key, my_blob) \
                                     VALUES (?, ?);";
 const SELECT_BLOB: &'static str = "SELECT * FROM my_ks.blob;";
+const CREATE_TABLE_TIMESTAMP: &'static str = "CREATE TABLE IF NOT EXISTS my_ks.timestamp \
+                                              (my_key int PRIMARY KEY, my_timestamp timestamp);";
+const INSERT_TIMESTAMP: &'static str = "INSERT INTO my_ks.timestamp (my_key, my_timestamp) \
+                                    VALUES (?, ?);";
+const SELECT_TIMESTAMP: &'static str = "SELECT * FROM my_ks.timestamp;";
 
 // we want to keep an order:
 // 1. create keyspace
@@ -212,6 +218,18 @@ fn main_crud_operations() {
 
     if select_table_blob(&mut session) {
         println!("30. blob table selected");
+    }
+
+    if create_table_timestamp(&mut session) {
+        println!("31. timestamp table created");
+    }
+
+    if insert_table_timestamp(&mut session) {
+        println!("32. timestamp table inserted");
+    }
+
+    if select_table_timestamp(&mut session) {
+        println!("33. timestamp table selected");
     }
 }
 
@@ -715,6 +733,55 @@ fn select_table_blob(session: &mut Session<NoneAuthenticator, TransportTcp>) -> 
 
     for row in all {
         let _: Vec<u8> = row.get_by_name("my_blob").expect("my_blob").unwrap();
+    }
+
+    true
+}
+
+fn create_table_timestamp(session: &mut Session<NoneAuthenticator, TransportTcp>) -> bool {
+    let q = QueryBuilder::new(CREATE_TABLE_TIMESTAMP).finalize();
+    match session.query(q, false, false) {
+        Err(ref err) => panic!("create_table timestamp {:?}", err),
+        Ok(_) => true,
+    }
+}
+
+fn insert_table_timestamp(session: &mut Session<NoneAuthenticator, TransportTcp>) -> bool {
+    let timestamp = time::Timespec {
+        sec: 1491938018,
+        nsec: 187_603_226,
+    };
+    let values: Vec<Value> = vec![(1 as i32).into(), timestamp.into()];
+
+    let query = QueryBuilder::new(INSERT_TIMESTAMP)
+        .values(values)
+        .finalize();
+    let inserted = session.query(query, false, false);
+    match inserted {
+        Err(ref err) => panic!("inserted timestamp {:?}", err),
+        Ok(_) => true,
+    }
+}
+
+fn select_table_timestamp(session: &mut Session<NoneAuthenticator, TransportTcp>) -> bool {
+    let select_query = QueryBuilder::new(SELECT_TIMESTAMP).finalize();
+    let all = session
+        .query(select_query, false, false)
+        .unwrap()
+        .get_body()
+        .unwrap()
+        .into_rows()
+        .unwrap();
+
+    for row in all {
+        let timestamp: time::Timespec = row.get_by_name("my_timestamp")
+            .expect("my_timestamp")
+            .unwrap();
+        assert_eq!(timestamp,
+                   time::Timespec {
+                       sec: 1491938018,
+                       nsec: 187_000_000,
+                   });
     }
 
     true


### PR DESCRIPTION
This makes it easy to store and retrieve time-stamps.
Time-stamps are stored as i64 according to the v4 protocol specs.