### PR TITLE
New into rust conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,8 +283,8 @@ let rows = res_body.into_rows().unwrap();
 let messages: Vec<CResult<Message>> = rows
     .iter()
     .map(|row| Message {
-        author: row.get_by_name("author").unwrap(),
-        text: row.get_by_name("text").unwrap()
+        author: row.r_by_name("author").unwrap(),
+        text: row.r_by_name("text").unwrap()
     })
     .collect();
 
@@ -308,10 +308,10 @@ let rows = res_body.into_rows().unwrap();
 let messages: Vec<CAuthor> = rows
     .iter()
     .map(|row| {
-        let name: String = row.get_by_name("name").unwrap();
+        let name: String = row.r_by_name("name").unwrap();
         let messages: Vec<String> = row
             // unwrap Option<CResult<T>>, where T implements AsRust
-            .get_by_name("messages").unwrap().unwrap()
+            .r_by_name("messages").unwrap().unwrap()
             .as_rust().unwrap();
         return Author {
             author: name,

--- a/examples/all.rs
+++ b/examples/all.rs
@@ -297,16 +297,10 @@ fn select_all_ints(session: &mut Session<NoneAuthenticator, TransportTcp>) -> bo
 
     for row in all {
         let _ = Ints {
-            bigint: row.get_by_name("my_bigint")
-                .expect("my_bigint")
-                .unwrap(),
-            int: row.get_by_name("my_int").expect("my_int").unwrap(),
-            smallint: row.get_by_name("my_smallint")
-                .expect("my_smallint")
-                .unwrap(),
-            tinyint: row.get_by_name("my_tinyint")
-                .expect("my_tinyint")
-                .unwrap(),
+            bigint: row.r_by_name("my_bigint").expect("my_bigint"),
+            int: row.r_by_name("my_int").expect("my_int"),
+            smallint: row.r_by_name("my_smallint").expect("my_smallint"),
+            tinyint: row.r_by_name("my_tinyint").expect("my_tinyint"),
         };
     }
 
@@ -369,11 +363,9 @@ fn select_table_str(session: &mut Session<NoneAuthenticator, TransportTcp>) -> b
 
     for row in all {
         let _ = Strings {
-            my_ascii: row.get_by_name("my_ascii").expect("my_ascii").unwrap(),
-            my_text: row.get_by_name("my_text").expect("my_text").unwrap(),
-            my_varchar: row.get_by_name("my_varchar")
-                .expect("my_ascii")
-                .unwrap(),
+            my_ascii: row.r_by_name("my_ascii").expect("my_ascii"),
+            my_text: row.r_by_name("my_text").expect("my_text"),
+            my_varchar: row.r_by_name("my_varchar").expect("my_ascii"),
         };
     }
 
@@ -420,27 +412,21 @@ fn select_table_list(session: &mut Session<NoneAuthenticator, TransportTcp>) -> 
 
     for row in all {
         let _ = Lists {
-            string_list: row.by_name::<List>("my_string_list") // intermediate type is required
+            string_list: row.r_by_name::<List>("my_string_list") // intermediate type is required
                 .expect("string_list")
-                .unwrap()
-                .as_rust::<Vec<String>>() // final type is not required, it could be find
+                .as_r_rust::<Vec<String>>() // final type is not required, it could be find
                 // authomatically
-                .unwrap()
                 .expect("string_list"),
-            number_list: row.by_name::<List>("my_number_list")
+            number_list: row.r_by_name::<List>("my_number_list")
                 .expect("number_list")
-                .unwrap()
-                .as_rust()
-                .expect("number_list")
-                .unwrap(),
-            complex_list: row.by_name::<List>("my_complex_list")
+                .as_r_rust()
+                .expect("number_list"),
+            complex_list: row.r_by_name::<List>("my_complex_list")
                 .expect("complex_list")
-                .unwrap()
-                .as_rust::<Vec<List>>()
+                .as_r_rust::<Vec<List>>()
                 .expect("my_complex_list")
-                .unwrap()
                 .iter()
-                .map(|it| it.as_rust().expect("number_list_c").unwrap())
+                .map(|it| it.as_r_rust().expect("number_list_c"))
                 .collect(),
         };
     }
@@ -496,41 +482,31 @@ fn select_table_map(session: &mut Session<NoneAuthenticator, TransportTcp>) -> b
 
     for row in all {
         let _ = Maps {
-            string_map: row.by_name::<Map>("my_string_map")
+            string_map: row.r_by_name::<Map>("my_string_map")
                 .expect("string_map")
-                .unwrap()
-                .as_rust()
-                .expect("string_map")
-                .unwrap(),
-            number_map: row.by_name::<Map>("my_number_map")
+                .as_r_rust()
+                .expect("string_map"),
+            number_map: row.r_by_name::<Map>("my_number_map")
                 .expect("number_map")
-                .unwrap()
-                .as_rust()
-                .expect("number_map")
-                .unwrap(),
-            complex_map: row.by_name::<Map>("my_complex_map")
+                .as_r_rust()
+                .expect("number_map"),
+            complex_map: row.r_by_name::<Map>("my_complex_map")
                 .expect("complex_map")
-                .unwrap()
-                .as_rust::<HashMap<String, Map>>()
+                .as_r_rust::<HashMap<String, Map>>()
                 .expect("my_complex_map")
-                .unwrap()
                 .iter()
                 .fold(HashMap::new(), |mut hm, (k, v)| {
-                    hm.insert(k.clone(), v.as_rust().expect("complex_map_c").unwrap());
+                    hm.insert(k.clone(), v.as_r_rust().expect("complex_map_c"));
                     hm
                 }),
-            int_key_map: row.by_name::<Map>("my_int_key_map")
+            int_key_map: row.r_by_name::<Map>("my_int_key_map")
                 .expect("int_key_map")
-                .unwrap()
-                .as_rust()
-                .expect("int_key_map")
-                .unwrap(),
-            uuid_key_map: row.by_name::<Map>("my_uuid_key_map")
+                .as_r_rust()
+                .expect("int_key_map"),
+            uuid_key_map: row.r_by_name::<Map>("my_uuid_key_map")
                 .expect("uuid_key_map")
-                .unwrap()
-                .as_rust()
-                .expect("uuid_key_map")
-                .unwrap(),
+                .as_r_rust()
+                .expect("uuid_key_map"),
         };
     }
 
@@ -578,12 +554,10 @@ fn select_table_udt(session: &mut Session<NoneAuthenticator, TransportTcp>) -> b
 
     for row in all {
         let _ = Udt {
-            number: row.by_name::<UDT>("my_udt")
+            number: row.r_by_name::<UDT>("my_udt")
                 .expect("my_udt")
-                .unwrap()
-                .by_name("number")
-                .expect("number")
-                .unwrap(),
+                .r_by_name("number")
+                .expect("number"),
         };
     }
 
@@ -621,9 +595,7 @@ fn select_table_bool(session: &mut Session<NoneAuthenticator, TransportTcp>) -> 
         .unwrap();
 
     for row in all {
-        let _: bool = row.get_by_name("my_boolean")
-            .expect("my_boolean")
-            .unwrap();
+        let _: bool = row.r_by_name("my_boolean").expect("my_boolean");
     }
 
     true
@@ -661,7 +633,7 @@ fn select_table_uuid(session: &mut Session<NoneAuthenticator, TransportTcp>) -> 
         .unwrap();
 
     for row in all {
-        let _: Uuid = row.get_by_name("my_uuid").expect("my_uuid").unwrap();
+        let _: Uuid = row.r_by_name("my_uuid").expect("my_uuid");
     }
 
     true
@@ -700,10 +672,8 @@ fn select_table_float(session: &mut Session<NoneAuthenticator, TransportTcp>) ->
         .unwrap();
 
     for row in all {
-        let _: f32 = row.get_by_name("my_float").expect("my_float").unwrap();
-        let _: f64 = row.get_by_name("my_double")
-            .expect("my_double")
-            .unwrap();
+        let _: f32 = row.r_by_name("my_float").expect("my_float");
+        let _: f64 = row.r_by_name("my_double").expect("my_double");
     }
 
     true
@@ -740,7 +710,7 @@ fn select_table_blob(session: &mut Session<NoneAuthenticator, TransportTcp>) -> 
         .unwrap();
 
     for row in all {
-        let _: Vec<u8> = row.get_by_name("my_blob").expect("my_blob").unwrap();
+        let _: Vec<u8> = row.r_by_name("my_blob").expect("my_blob");
     }
 
     true
@@ -779,9 +749,7 @@ fn select_table_timestamp(session: &mut Session<NoneAuthenticator, TransportTcp>
         .unwrap();
 
     for row in all {
-        let _: time::Timespec = row.get_by_name("my_timestamp")
-            .expect("my_timestamp")
-            .unwrap();
+        let _: time::Timespec = row.r_by_name("my_timestamp").expect("my_timestamp");
     }
 
     true

--- a/examples/all.rs
+++ b/examples/all.rs
@@ -425,19 +425,22 @@ fn select_table_list(session: &mut Session<NoneAuthenticator, TransportTcp>) -> 
                 .unwrap()
                 .as_rust::<Vec<String>>() // final type is not required, it could be find
                 // authomatically
+                .unwrap()
                 .expect("string_list"),
             number_list: row.by_name::<List>("my_number_list")
                 .expect("number_list")
                 .unwrap()
                 .as_rust()
-                .expect("number_list"),
+                .expect("number_list")
+                .unwrap(),
             complex_list: row.by_name::<List>("my_complex_list")
                 .expect("complex_list")
                 .unwrap()
                 .as_rust::<Vec<List>>()
                 .expect("my_complex_list")
+                .unwrap()
                 .iter()
-                .map(|it| it.as_rust().expect("number_list_c"))
+                .map(|it| it.as_rust().expect("number_list_c").unwrap())
                 .collect(),
         };
     }
@@ -497,32 +500,37 @@ fn select_table_map(session: &mut Session<NoneAuthenticator, TransportTcp>) -> b
                 .expect("string_map")
                 .unwrap()
                 .as_rust()
-                .expect("string_map"),
+                .expect("string_map")
+                .unwrap(),
             number_map: row.by_name::<Map>("my_number_map")
                 .expect("number_map")
                 .unwrap()
                 .as_rust()
-                .expect("number_map"),
+                .expect("number_map")
+                .unwrap(),
             complex_map: row.by_name::<Map>("my_complex_map")
                 .expect("complex_map")
                 .unwrap()
                 .as_rust::<HashMap<String, Map>>()
                 .expect("my_complex_map")
+                .unwrap()
                 .iter()
                 .fold(HashMap::new(), |mut hm, (k, v)| {
-                    hm.insert(k.clone(), v.as_rust().expect("complex_map_c"));
+                    hm.insert(k.clone(), v.as_rust().expect("complex_map_c").unwrap());
                     hm
                 }),
             int_key_map: row.by_name::<Map>("my_int_key_map")
                 .expect("int_key_map")
                 .unwrap()
                 .as_rust()
-                .expect("int_key_map"),
+                .expect("int_key_map")
+                .unwrap(),
             uuid_key_map: row.by_name::<Map>("my_uuid_key_map")
                 .expect("uuid_key_map")
                 .unwrap()
                 .as_rust()
-                .expect("uuid_key_map"),
+                .expect("uuid_key_map")
+                .unwrap(),
         };
     }
 

--- a/examples/read_table_into_struct.rs
+++ b/examples/read_table_into_struct.rs
@@ -64,23 +64,23 @@ fn main() {
                         let employees: Vec<Employee> = rows.iter()
                             .map(|row| {
                                 let mut employee = Employee { ..Default::default() };
-                                if let Some(Ok(id)) = row.get_by_name("emp_id") {
+                                if let Ok(Some(id)) = row.get_by_name("emp_id") {
                                     employee.id = id;
                                 }
 
-                                if let Some(Ok(emp_name)) = row.get_by_name("emp_name") {
+                                if let Ok(Some(emp_name)) = row.get_by_name("emp_name") {
                                     employee.emp_name = emp_name;
                                 }
 
-                                if let Some(Ok(emp_city)) = row.get_by_name("emp_city") {
+                                if let Ok(Some(emp_city)) = row.get_by_name("emp_city") {
                                     employee.emp_city = emp_city;
                                 }
 
-                                if let Some(Ok(emp_sal)) = row.get_by_name("emp_sal") {
+                                if let Ok(Some(emp_sal)) = row.get_by_name("emp_sal") {
                                     employee.emp_sal = emp_sal;
                                 }
 
-                                if let Some(Ok(emp_phone)) = row.get_by_name("emp_phone") {
+                                if let Ok(Some(emp_phone)) = row.get_by_name("emp_phone") {
                                     employee.emp_phone = emp_phone;
                                 }
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -64,23 +64,23 @@ fn main() {
                         let employees: Vec<Employee> = rows.iter()
                             .map(|row| {
                                 let mut employee = Employee { ..Default::default() };
-                                if let Some(Ok(id)) = row.get_by_name("emp_id") {
+                                if let Ok(Some(id)) = row.get_by_name("emp_id") {
                                     employee.id = id;
                                 }
 
-                                if let Some(Ok(emp_name)) = row.get_by_name("emp_name") {
+                                if let Ok(Some(emp_name)) = row.get_by_name("emp_name") {
                                     employee.emp_name = emp_name;
                                 }
 
-                                if let Some(Ok(emp_city)) = row.get_by_name("emp_city") {
+                                if let Ok(Some(emp_city)) = row.get_by_name("emp_city") {
                                     employee.emp_city = emp_city;
                                 }
 
-                                if let Some(Ok(emp_sal)) = row.get_by_name("emp_sal") {
+                                if let Ok(Some(emp_sal)) = row.get_by_name("emp_sal") {
                                     employee.emp_sal = emp_sal;
                                 }
 
-                                if let Some(Ok(emp_phone)) = row.get_by_name("emp_phone") {
+                                if let Ok(Some(emp_phone)) = row.get_by_name("emp_phone") {
                                     employee.emp_phone = emp_phone;
                                 }
 

--- a/src/authenticators.rs
+++ b/src/authenticators.rs
@@ -80,14 +80,14 @@ mod tests {
         expected_token.push(0);
         expected_token.extend_from_slice("bar".as_bytes());
 
-        assert_eq!(auth.get_auth_token().into_plain(), expected_token);
+        assert_eq!(auth.get_auth_token().into_plain().unwrap(), expected_token);
     }
 
     #[test]
     fn test_authenticator_none_get_cassandra_name() {
         let auth = NoneAuthenticator;
         assert_eq!(auth.get_cassandra_name(), None);
-        assert_eq!(auth.get_auth_token().into_plain(), vec![0]);
+        assert_eq!(auth.get_auth_token().into_plain().unwrap(), vec![0]);
     }
 
     fn authenticator_tester<A: Authenticator>(_authenticator: Box<A>) {}

--- a/src/frame/frame_auth_challenge.rs
+++ b/src/frame/frame_auth_challenge.rs
@@ -27,6 +27,7 @@ mod tests {
         let few_bytes = &[0, 0, 0, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
         let mut cursor: Cursor<&[u8]> = Cursor::new(few_bytes);
         let body = BodyResAuthChallenge::from_cursor(&mut cursor).unwrap();
-        assert_eq!(body.data.into_plain(), vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        assert_eq!(body.data.into_plain().unwrap(),
+                   vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -91,10 +91,6 @@ macro_rules! into_rust_by_name {
                 self.get_col_spec_by_name(name)
                     .ok_or(column_is_empty_err())
                     .and_then(|(col_spec, cbytes)| {
-                        // if cbytes.is_empty() {
-                        //     return Err(column_is_empty_err());
-                        // }
-
                         let ref col_type = col_spec.col_type;
                         as_rust_type!(col_type, cbytes, $($into_type)*)
                     })
@@ -109,11 +105,6 @@ macro_rules! into_rust_by_name {
                 .ok_or(column_is_empty_err())
                 .and_then(|v| {
                     let &(ref col_type, ref bytes) = v;
-
-                    // if bytes.as_plain().is_empty() {
-                    //     return Err(column_is_empty_err());
-                    // }
-
                     let converted = as_rust_type!(col_type, bytes, $($into_type)*);
                     converted.map_err(|err| err.into())
                 })
@@ -143,8 +134,6 @@ macro_rules! as_rust_type {
         match $data_type_option.id {
             ColType::Blob => {
                 as_res_opt!($data_value, decode_blob)
-                // decode_blob($data_value.as_plain())
-                //     .map_err(Into::into)
             }
             _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into Vec<u8> (valid types: Blob).",
@@ -155,18 +144,12 @@ macro_rules! as_rust_type {
         match $data_type_option.id {
             ColType::Custom => {
                 as_res_opt!($data_value, decode_custom)
-                // decode_custom($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             ColType::Ascii => {
                 as_res_opt!($data_value, decode_ascii)
-                // decode_ascii($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             ColType::Varchar => {
                 as_res_opt!($data_value, decode_varchar)
-                // decode_varchar($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             // TODO: clarify when to use decode_text.
             // it's not mentioned in
@@ -181,8 +164,6 @@ macro_rules! as_rust_type {
         match $data_type_option.id {
             ColType::Boolean => {
                 as_res_opt!($data_value, decode_boolean)
-                // decode_boolean($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into bool (valid types: Boolean).",
@@ -193,23 +174,15 @@ macro_rules! as_rust_type {
         match $data_type_option.id {
             ColType::Bigint => {
                 as_res_opt!($data_value, decode_bigint)
-                // decode_bigint($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             ColType::Timestamp => {
                 as_res_opt!($data_value, decode_timestamp)
-                // decode_timestamp($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             ColType::Time => {
                 as_res_opt!($data_value, decode_time)
-                // decode_time($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             ColType::Varint => {
                 as_res_opt!($data_value, decode_varint)
-                // decode_varint($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into i64 (valid types: Bigint, Timestamp, Time, Variant).",
@@ -220,13 +193,9 @@ macro_rules! as_rust_type {
         match $data_type_option.id {
             ColType::Int => {
                 as_res_opt!($data_value, decode_int)
-                // decode_int($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             ColType::Date => {
                 as_res_opt!($data_value, decode_date)
-                // decode_date($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into i32 (valid types: Int, Date).",
@@ -237,8 +206,6 @@ macro_rules! as_rust_type {
         match $data_type_option.id {
             ColType::Smallint => {
                 as_res_opt!($data_value, decode_smallint)
-                // decode_smallint($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into i16 (valid types: Smallint).",
@@ -249,8 +216,6 @@ macro_rules! as_rust_type {
         match $data_type_option.id {
             ColType::Tinyint => {
                 as_res_opt!($data_value, decode_tinyint)
-                // decode_tinyint($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into i8 (valid types: Tinyint).",
@@ -261,8 +226,6 @@ macro_rules! as_rust_type {
         match $data_type_option.id {
             ColType::Double => {
                 as_res_opt!($data_value, decode_double)
-                // decode_double($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into f64 (valid types: Double).",
@@ -273,13 +236,9 @@ macro_rules! as_rust_type {
         match $data_type_option.id {
             ColType::Decimal => {
                 as_res_opt!($data_value, decode_decimal)
-                // decode_decimal($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             ColType::Float => {
                 as_res_opt!($data_value, decode_float)
-                // decode_float($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into f32 (valid types: Decimal, Float).",
@@ -290,8 +249,6 @@ macro_rules! as_rust_type {
         match $data_type_option.id {
             ColType::Inet => {
                 as_res_opt!($data_value, decode_inet)
-                // decode_inet($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into IpAddr (valid types: Inet).",
@@ -303,8 +260,6 @@ macro_rules! as_rust_type {
             ColType::Uuid |
             ColType::Timeuuid => {
                 as_res_opt!($data_value, decode_timeuuid)
-                // decode_timeuuid($data_value.as_slice())
-                //     .map_err(Into::into)
             }
             _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into Uuid (valid types: Uuid, Timeuuid).",
@@ -360,10 +315,6 @@ macro_rules! as_rust_type {
                     },
                     None => Ok(None)
                 }
-                // XXX: unwrap Option
-                // decode_udt($data_value.as_slice().unwrap(), list_type_option.descriptions.len())
-                //     .map(|data| Some(UDT::new(data, list_type_option)))
-                //     .map_err(Into::into)
             }
             _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into UDT (valid types: UDT).",
@@ -382,9 +333,6 @@ macro_rules! as_rust_type {
                     },
                     None => Ok(None)
                 }
-                // decode_timestamp($data_value.as_slice().unwrap())
-                //     .map(|ts| Some(Timespec::new(ts / 1_000, (ts % 1_000 * 1_000_000) as i32)))
-                //     .map_err(Into::into)
             }
             _ => Err(Error::General(format!("Invalid conversion. \
                     Cannot convert {:?} into Timespec (valid types: Timestamp).",

--- a/src/types/data_serialization_types.rs
+++ b/src/types/data_serialization_types.rs
@@ -30,9 +30,9 @@ pub fn decode_bigint(bytes: &[u8]) -> Result<i64, io::Error> {
 }
 
 // Decodes Cassandra `blob` data (bytes) into Rust's `Result<Vec<u8>, io::Error>`
-pub fn decode_blob(bytes: Vec<u8>) -> Result<Vec<u8>, io::Error> {
+pub fn decode_blob(bytes: &Vec<u8>) -> Result<Vec<u8>, io::Error> {
     // in fact we just pass it through.
-    Ok(bytes)
+    Ok(bytes.clone())
 }
 
 // Decodes Cassandra `boolean` data (bytes) into Rust's `Result<i32, io::Error>`

--- a/src/types/data_serialization_types.rs
+++ b/src/types/data_serialization_types.rs
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn decode_blob_test() {
-        assert_eq!(decode_blob(vec![0, 0, 0, 3]).unwrap(), vec![0, 0, 0, 3]);
+        assert_eq!(decode_blob(&vec![0, 0, 0, 3]).unwrap(), vec![0, 0, 0, 3]);
     }
 
     #[test]
@@ -277,22 +277,22 @@ mod tests {
     fn decode_list_test() {
         let results = decode_list(&[0, 0, 0, 1, 0, 0, 0, 2, 1, 2]).unwrap();
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].as_plain(), vec![1, 2]);
+        assert_eq!(results[0].as_plain().unwrap(), vec![1, 2]);
     }
 
     #[test]
     fn decode_set_test() {
         let results = decode_set(&[0, 0, 0, 1, 0, 0, 0, 2, 1, 2]).unwrap();
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].as_plain(), vec![1, 2]);
+        assert_eq!(results[0].as_plain().unwrap(), vec![1, 2]);
     }
 
     #[test]
     fn decode_map_test() {
         let results = decode_map(&[0, 0, 0, 1, 0, 0, 0, 2, 1, 2, 0, 0, 0, 2, 2, 1]).unwrap();
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].0.as_plain(), vec![1, 2]);
-        assert_eq!(results[0].1.as_plain(), vec![2, 1]);
+        assert_eq!(results[0].0.as_plain().unwrap(), vec![1, 2]);
+        assert_eq!(results[0].1.as_plain().unwrap(), vec![2, 1]);
     }
 
     #[test]
@@ -332,14 +332,15 @@ mod tests {
     fn decode_udt_test() {
         let udt = decode_udt(&[0, 0, 0, 2, 1, 2], 1).unwrap();
         assert_eq!(udt.len(), 1);
-        assert_eq!(udt[0].as_plain(), vec![1, 2]);
+        assert_eq!(udt[0].as_plain().unwrap(), vec![1, 2]);
     }
 
     #[test]
     fn as_rust_blob_test() {
         let d_type = DataType { id: ColType::Blob };
         let data = CBytes::new(vec![1, 2, 3]);
-        assert_eq!(as_rust_type!(d_type, data, Vec<u8>).unwrap(), vec![1, 2, 3]);
+        assert_eq!(as_rust_type!(d_type, data, Vec<u8>).unwrap().unwrap(),
+                   vec![1, 2, 3]);
         let wrong_type = DataType { id: ColType::Map };
         assert!(as_rust_type!(wrong_type, data, Vec<u8>).is_err());
     }
@@ -350,9 +351,9 @@ mod tests {
         let type_ascii = DataType { id: ColType::Ascii };
         let type_varchar = DataType { id: ColType::Varchar };
         let data = CBytes::new(b"abc".to_vec());
-        assert_eq!(as_rust_type!(type_custom, data, String).unwrap(), "abc");
-        assert_eq!(as_rust_type!(type_ascii, data, String).unwrap(), "abc");
-        assert_eq!(as_rust_type!(type_varchar, data, String).unwrap(), "abc");
+        assert_eq!(as_rust_type!(type_custom, data, String).unwrap().unwrap(), "abc");
+        assert_eq!(as_rust_type!(type_ascii, data, String).unwrap().unwrap(), "abc");
+        assert_eq!(as_rust_type!(type_varchar, data, String).unwrap().unwrap(), "abc");
         let wrong_type = DataType { id: ColType::Map };
         assert!(as_rust_type!(wrong_type, data, String).is_err());
     }
@@ -362,8 +363,8 @@ mod tests {
         let type_boolean = DataType { id: ColType::Boolean };
         let data_true = CBytes::new(vec![1]);
         let data_false = CBytes::new(vec![0]);
-        assert_eq!(as_rust_type!(type_boolean, data_true, bool).unwrap(), true);
-        assert_eq!(as_rust_type!(type_boolean, data_false, bool).unwrap(), false);
+        assert_eq!(as_rust_type!(type_boolean, data_true, bool).unwrap().unwrap(), true);
+        assert_eq!(as_rust_type!(type_boolean, data_false, bool).unwrap().unwrap(), false);
         let wrong_type = DataType { id: ColType::Map };
         assert!(as_rust_type!(wrong_type, data_false, bool).is_err());
     }
@@ -375,10 +376,10 @@ mod tests {
         let type_time = DataType { id: ColType::Time };
         let type_varint = DataType { id: ColType::Varint };
         let data = CBytes::new(vec![0, 0, 0, 0, 0, 0, 0, 100]);
-        assert_eq!(as_rust_type!(type_bigint, data, i64).unwrap(), 100);
-        assert_eq!(as_rust_type!(type_timestamp, data, i64).unwrap(), 100);
-        assert_eq!(as_rust_type!(type_time, data, i64).unwrap(), 100);
-        assert_eq!(as_rust_type!(type_varint, data, i64).unwrap(), 100);
+        assert_eq!(as_rust_type!(type_bigint, data, i64).unwrap().unwrap(), 100);
+        assert_eq!(as_rust_type!(type_timestamp, data, i64).unwrap().unwrap(), 100);
+        assert_eq!(as_rust_type!(type_time, data, i64).unwrap().unwrap(), 100);
+        assert_eq!(as_rust_type!(type_varint, data, i64).unwrap().unwrap(), 100);
         let wrong_type = DataType { id: ColType::Map };
         assert!(as_rust_type!(wrong_type, data, i64).is_err());
     }
@@ -388,8 +389,8 @@ mod tests {
         let type_int = DataType { id: ColType::Int };
         let type_date = DataType { id: ColType::Date };
         let data = CBytes::new(vec![ 0, 0, 0, 100]);
-        assert_eq!(as_rust_type!(type_int, data, i32).unwrap(), 100);
-        assert_eq!(as_rust_type!(type_date, data, i32).unwrap(), 100);
+        assert_eq!(as_rust_type!(type_int, data, i32).unwrap().unwrap(), 100);
+        assert_eq!(as_rust_type!(type_date, data, i32).unwrap().unwrap(), 100);
         let wrong_type = DataType { id: ColType::Map };
         assert!(as_rust_type!(wrong_type, data, i32).is_err());
     }
@@ -398,7 +399,7 @@ mod tests {
     fn as_rust_i16_test() {
         let type_smallint = DataType { id: ColType::Smallint };
         let data = CBytes::new(vec![0, 100]);
-        assert_eq!(as_rust_type!(type_smallint, data, i16).unwrap(), 100);
+        assert_eq!(as_rust_type!(type_smallint, data, i16).unwrap().unwrap(), 100);
         let wrong_type = DataType { id: ColType::Map };
         assert!(as_rust_type!(wrong_type, data, i16).is_err());
     }
@@ -407,7 +408,7 @@ mod tests {
     fn as_rust_i8_test() {
         let type_tinyint = DataType { id: ColType::Tinyint };
         let data = CBytes::new(vec![100]);
-        assert_eq!(as_rust_type!(type_tinyint, data, i8).unwrap(), 100);
+        assert_eq!(as_rust_type!(type_tinyint, data, i8).unwrap().unwrap(), 100);
         let wrong_type = DataType { id: ColType::Map };
         assert!(as_rust_type!(wrong_type, data, i8).is_err());
     }
@@ -416,7 +417,7 @@ mod tests {
     fn as_rust_f64_test() {
         let type_double = DataType { id: ColType::Double };
         let data = CBytes::new(to_float_big(0.1 as f64));
-        assert_eq!(as_rust_type!(type_double, data, f64).unwrap(), 0.1);
+        assert_eq!(as_rust_type!(type_double, data, f64).unwrap().unwrap(), 0.1);
         let wrong_type = DataType { id: ColType::Map };
         assert!(as_rust_type!(wrong_type, data, f64).is_err());
     }
@@ -427,7 +428,7 @@ mod tests {
         let type_float = DataType { id: ColType::Float };
         let data = CBytes::new(to_float(0.1 as f32));
         // assert_eq!(as_rust_type!(type_decimal, data, f32).unwrap(), 100.0);
-        assert_eq!(as_rust_type!(type_float, data, f32).unwrap(), 0.1);
+        assert_eq!(as_rust_type!(type_float, data, f32).unwrap().unwrap(), 0.1);
         let wrong_type = DataType { id: ColType::Map };
         assert!(as_rust_type!(wrong_type, data, f32).is_err());
     }
@@ -438,7 +439,7 @@ mod tests {
         let data = CBytes::new(vec![0, 0, 0, 0]);
 
         match as_rust_type!(type_inet, data, IpAddr) {
-            Ok(IpAddr::V4(ref ip)) => assert_eq!(ip.octets(), [0, 0, 0, 0]),
+            Ok(Some(IpAddr::V4(ref ip))) => assert_eq!(ip.octets(), [0, 0, 0, 0]),
             _ => panic!("wrong ip v4 address"),
         }
         let wrong_type = DataType { id: ColType::Map };

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -35,18 +35,25 @@ impl AsRust for List {}
 
 impl AsRustType<Vec<Vec<u8>>> for List {
     /// Converts cassandra list of blobs into Rust `Vec<Vec<u8>>`
-    fn as_rust_type(&self) -> Result<Vec<Vec<u8>>> {
+    fn as_rust_type(&self) -> Result<Option<Vec<Vec<u8>>>> {
         match self.metadata.value {
             Some(ColTypeOptionValue::CList(ref type_option)) => {
                 match type_option.id {
                     // XXX unwrap
-                    ColType::Blob => Ok(self.map(|bytes| decode_blob(bytes.as_plain()).unwrap())),
+                    ColType::Blob => {
+                        Ok(self.map(|bytes| decode_blob(&bytes.as_plain().unwrap()).unwrap()))
+                            .map(Some)
+                    }
                     _ => unreachable!(),
                 }
             }
             Some(ColTypeOptionValue::CSet(ref type_option)) => {
                 match type_option.id {
-                    ColType::Blob => Ok(self.map(|bytes| decode_blob(bytes.as_plain()).unwrap())),
+                    ColType::Blob => {
+                        // XXX unwrap
+                        Ok(self.map(|bytes| decode_blob(&bytes.as_plain().unwrap()).unwrap()))
+                            .map(Some)
+                    }
                     _ => unreachable!(),
                 }
             }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -707,7 +707,7 @@ mod tests {
     #[test]
     fn test_cbytes_into_plain() {
         let cbytes = CBytes::new(vec![1, 2, 3]);
-        assert_eq!(cbytes.into_plain(), &[1, 2, 3]);
+        assert_eq!(cbytes.into_plain().unwrap(), &[1, 2, 3]);
     }
 
     #[test]
@@ -715,14 +715,14 @@ mod tests {
         let a = &[0, 0, 0, 3, 1, 2, 3];
         let mut cursor: Cursor<&[u8]> = Cursor::new(a);
         let cbytes = CBytes::from_cursor(&mut cursor).unwrap();
-        assert_eq!(cbytes.into_plain(), &[1, 2, 3]);
+        assert_eq!(cbytes.into_plain().unwrap(), vec![1, 2, 3]);
     }
 
     #[test]
     fn test_cbytes_into_cbytes() {
         let bytes_vec = vec![1, 2, 3];
         let cbytes = CBytes::new(bytes_vec);
-        assert_eq!(cbytes.into_cbytes(), &[0, 0, 0, 3, 1, 2, 3]);
+        assert_eq!(cbytes.into_cbytes(), vec![0, 0, 0, 3, 1, 2, 3]);
     }
 
     // CBytesShort
@@ -735,7 +735,7 @@ mod tests {
     #[test]
     fn test_cbytesshort_into_plain() {
         let cbytes = CBytesShort::new(vec![1, 2, 3]);
-        assert_eq!(cbytes.into_plain(), &[1, 2, 3]);
+        assert_eq!(cbytes.into_plain().unwrap(), vec![1, 2, 3]);
     }
 
     #[test]
@@ -743,14 +743,14 @@ mod tests {
         let a = &[0, 3, 1, 2, 3];
         let mut cursor: Cursor<&[u8]> = Cursor::new(a);
         let cbytes = CBytesShort::from_cursor(&mut cursor).unwrap();
-        assert_eq!(cbytes.into_plain(), &[1, 2, 3]);
+        assert_eq!(cbytes.into_plain().unwrap(), vec![1, 2, 3]);
     }
 
     #[test]
     fn test_cbytesshort_into_cbytes() {
         let bytes_vec: Vec<u8> = vec![1, 2, 3];
         let cbytes = CBytesShort::new(bytes_vec);
-        assert_eq!(cbytes.into_cbytes(), &[0, 3, 1, 2, 3]);
+        assert_eq!(cbytes.into_cbytes(), vec![0, 3, 1, 2, 3]);
     }
 
     // CInt

--- a/src/types/rows.rs
+++ b/src/types/rows.rs
@@ -44,12 +44,13 @@ impl Row {
 }
 
 impl IntoRustByName<Vec<u8>> for Row {
-    fn get_by_name(&self, name: &str) -> Option<Result<Vec<u8>>> {
+    fn get_by_name(&self, name: &str) -> Result<Option<Vec<u8>>> {
         self.get_col_spec_by_name(name)
-            .map(|(col_spec, cbytes)| {
-                     let ref col_type = col_spec.col_type;
-                     as_rust_type!(col_type, cbytes, Vec<u8>)
-                 })
+            .ok_or(column_is_empty_err())
+            .and_then(|(col_spec, cbytes)| {
+                          let ref col_type = col_spec.col_type;
+                          as_rust_type!(col_type, cbytes, Vec<u8>)
+                      })
     }
 }
 

--- a/tests/create_insert_table.rs
+++ b/tests/create_insert_table.rs
@@ -124,32 +124,32 @@ fn read_from_user_table() {
 
     match query_op {
         Ok(res) => {
-            let res_body = res.get_body().unwrap();
+            let res_body = res.get_body().expect("shold have body");
             if let Some(rows) = res_body.into_rows() {
                 let users: Vec<User> = rows.iter()
                     .map(|row| {
                         let mut user = User { ..Default::default() };
-                        if let Some(Ok(user_name)) = row.get_by_name("user_name") {
+                        if let Ok(Some(user_name)) = row.get_by_name("user_name") {
                             user.user_name = user_name;
                         }
 
-                        if let Some(Ok(password)) = row.get_by_name("password") {
+                        if let Ok(Some(password)) = row.get_by_name("password") {
                             user.password = password;
                         }
 
-                        if let Some(Ok(gender)) = row.get_by_name("gender") {
+                        if let Ok(Some(gender)) = row.get_by_name("gender") {
                             user.gender = gender;
                         }
 
-                        if let Some(Ok(session_token)) = row.get_by_name("session_token") {
+                        if let Ok(Some(session_token)) = row.get_by_name("session_token") {
                             user.session_token = session_token;
                         }
 
-                        if let Some(Ok(state)) = row.get_by_name("state") {
+                        if let Ok(Some(state)) = row.get_by_name("state") {
                             user.state = state;
                         }
 
-                        if let Some(Ok(m)) = row.get_by_name("some_map") {
+                        if let Ok(Some(m)) = row.get_by_name("some_map") {
                             user.some_map = Some(m);
                         }
 

--- a/tests/crud_operations.rs
+++ b/tests/crud_operations.rs
@@ -435,19 +435,22 @@ fn select_table_list(session: &mut Session<NoneAuthenticator, TransportTcp>) -> 
                 .unwrap()
                 .as_rust::<Vec<String>>() // final type is not required, it could be find
                 // authomatically
-                .expect("string_list"),
+                .expect("string_list")
+                .unwrap(),
             number_list: row.by_name::<List>("my_number_list")
                 .expect("number_list")
                 .unwrap()
                 .as_rust()
-                .expect("number_list"),
+                .expect("number_list")
+                .unwrap(),
             complex_list: row.by_name::<List>("my_complex_list")
                 .expect("complex_list")
                 .unwrap()
                 .as_rust::<Vec<List>>()
                 .expect("my_complex_list")
+                .unwrap()
                 .iter()
-                .map(|it| it.as_rust().expect("number_list_c"))
+                .map(|it| it.as_rust().expect("number_list_c").unwrap())
                 .collect(),
         };
     }
@@ -507,32 +510,37 @@ fn select_table_map(session: &mut Session<NoneAuthenticator, TransportTcp>) -> b
                 .expect("string_map")
                 .unwrap()
                 .as_rust()
-                .expect("string_map"),
+                .expect("string_map")
+                .unwrap(),
             number_map: row.by_name::<Map>("my_number_map")
                 .expect("number_map")
                 .unwrap()
                 .as_rust()
-                .expect("number_map"),
+                .expect("number_map")
+                .unwrap(),
             complex_map: row.by_name::<Map>("my_complex_map")
                 .expect("complex_map")
                 .unwrap()
                 .as_rust::<HashMap<String, Map>>()
                 .expect("my_complex_map")
+                .unwrap()
                 .iter()
                 .fold(HashMap::new(), |mut hm, (k, v)| {
-                    hm.insert(k.clone(), v.as_rust().expect("complex_map_c"));
+                    hm.insert(k.clone(), v.as_rust().expect("complex_map_c").unwrap());
                     hm
                 }),
             int_key_map: row.by_name::<Map>("my_int_key_map")
                 .expect("int_key_map")
                 .unwrap()
                 .as_rust()
-                .expect("int_key_map"),
+                .expect("int_key_map")
+                .unwrap(),
             uuid_key_map: row.by_name::<Map>("my_uuid_key_map")
                 .expect("uuid_key_map")
                 .unwrap()
                 .as_rust()
-                .expect("uuid_key_map"),
+                .expect("uuid_key_map")
+                .unwrap(),
         };
     }
 

--- a/tests/crud_operations.rs
+++ b/tests/crud_operations.rs
@@ -307,16 +307,10 @@ fn select_all_ints(session: &mut Session<NoneAuthenticator, TransportTcp>) -> bo
 
     for row in all {
         let _ = Ints {
-            bigint: row.get_by_name("my_bigint")
-                .expect("my_bigint")
-                .unwrap(),
-            int: row.get_by_name("my_int").expect("my_int").unwrap(),
-            smallint: row.get_by_name("my_smallint")
-                .expect("my_smallint")
-                .unwrap(),
-            tinyint: row.get_by_name("my_tinyint")
-                .expect("my_tinyint")
-                .unwrap(),
+            bigint: row.r_by_name("my_bigint").expect("my_bigint"),
+            int: row.r_by_name("my_int").expect("my_int"),
+            smallint: row.r_by_name("my_smallint").expect("my_smallint"),
+            tinyint: row.r_by_name("my_tinyint").expect("my_tinyint"),
         };
     }
 
@@ -379,11 +373,9 @@ fn select_table_str(session: &mut Session<NoneAuthenticator, TransportTcp>) -> b
 
     for row in all {
         let _ = Strings {
-            my_ascii: row.get_by_name("my_ascii").expect("my_ascii").unwrap(),
-            my_text: row.get_by_name("my_text").expect("my_text").unwrap(),
-            my_varchar: row.get_by_name("my_varchar")
-                .expect("my_ascii")
-                .unwrap(),
+            my_ascii: row.r_by_name("my_ascii").expect("my_ascii"),
+            my_text: row.r_by_name("my_text").expect("my_text"),
+            my_varchar: row.r_by_name("my_varchar").expect("my_ascii"),
         };
     }
 
@@ -430,27 +422,21 @@ fn select_table_list(session: &mut Session<NoneAuthenticator, TransportTcp>) -> 
 
     for row in all {
         let _ = Lists {
-            string_list: row.by_name::<List>("my_string_list") // intermediate type is required
+            string_list: row.r_by_name::<List>("my_string_list") // intermediate type is required
                 .expect("string_list")
-                .unwrap()
-                .as_rust::<Vec<String>>() // final type is not required, it could be find
+                .as_r_rust::<Vec<String>>() // final type is not required, it could be find
                 // authomatically
-                .expect("string_list")
-                .unwrap(),
-            number_list: row.by_name::<List>("my_number_list")
+                .expect("string_list"),
+            number_list: row.r_by_name::<List>("my_number_list")
                 .expect("number_list")
-                .unwrap()
-                .as_rust()
-                .expect("number_list")
-                .unwrap(),
-            complex_list: row.by_name::<List>("my_complex_list")
+                .as_r_rust()
+                .expect("number_list"),
+            complex_list: row.r_by_name::<List>("my_complex_list")
                 .expect("complex_list")
-                .unwrap()
-                .as_rust::<Vec<List>>()
+                .as_r_rust::<Vec<List>>()
                 .expect("my_complex_list")
-                .unwrap()
                 .iter()
-                .map(|it| it.as_rust().expect("number_list_c").unwrap())
+                .map(|it| it.as_r_rust().expect("number_list_c"))
                 .collect(),
         };
     }
@@ -506,41 +492,31 @@ fn select_table_map(session: &mut Session<NoneAuthenticator, TransportTcp>) -> b
 
     for row in all {
         let _ = Maps {
-            string_map: row.by_name::<Map>("my_string_map")
+            string_map: row.r_by_name::<Map>("my_string_map")
                 .expect("string_map")
-                .unwrap()
-                .as_rust()
-                .expect("string_map")
-                .unwrap(),
-            number_map: row.by_name::<Map>("my_number_map")
+                .as_r_rust()
+                .expect("string_map"),
+            number_map: row.r_by_name::<Map>("my_number_map")
                 .expect("number_map")
-                .unwrap()
-                .as_rust()
-                .expect("number_map")
-                .unwrap(),
-            complex_map: row.by_name::<Map>("my_complex_map")
+                .as_r_rust()
+                .expect("number_map"),
+            complex_map: row.r_by_name::<Map>("my_complex_map")
                 .expect("complex_map")
-                .unwrap()
-                .as_rust::<HashMap<String, Map>>()
+                .as_r_rust::<HashMap<String, Map>>()
                 .expect("my_complex_map")
-                .unwrap()
                 .iter()
                 .fold(HashMap::new(), |mut hm, (k, v)| {
-                    hm.insert(k.clone(), v.as_rust().expect("complex_map_c").unwrap());
+                    hm.insert(k.clone(), v.as_r_rust().expect("complex_map_c"));
                     hm
                 }),
-            int_key_map: row.by_name::<Map>("my_int_key_map")
+            int_key_map: row.r_by_name::<Map>("my_int_key_map")
                 .expect("int_key_map")
-                .unwrap()
-                .as_rust()
-                .expect("int_key_map")
-                .unwrap(),
-            uuid_key_map: row.by_name::<Map>("my_uuid_key_map")
+                .as_r_rust()
+                .expect("int_key_map"),
+            uuid_key_map: row.r_by_name::<Map>("my_uuid_key_map")
                 .expect("uuid_key_map")
-                .unwrap()
-                .as_rust()
-                .expect("uuid_key_map")
-                .unwrap(),
+                .as_r_rust()
+                .expect("uuid_key_map"),
         };
     }
 
@@ -588,12 +564,10 @@ fn select_table_udt(session: &mut Session<NoneAuthenticator, TransportTcp>) -> b
 
     for row in all {
         let _ = Udt {
-            number: row.by_name::<UDT>("my_udt")
+            number: row.r_by_name::<UDT>("my_udt")
                 .expect("my_udt")
-                .unwrap()
-                .by_name("number")
-                .expect("number")
-                .unwrap(),
+                .r_by_name("number")
+                .expect("number"),
         };
     }
 
@@ -631,9 +605,7 @@ fn select_table_bool(session: &mut Session<NoneAuthenticator, TransportTcp>) -> 
         .unwrap();
 
     for row in all {
-        let _: bool = row.get_by_name("my_boolean")
-            .expect("my_boolean")
-            .unwrap();
+        let _: bool = row.r_by_name("my_boolean").expect("my_boolean");
     }
 
     true
@@ -671,7 +643,7 @@ fn select_table_uuid(session: &mut Session<NoneAuthenticator, TransportTcp>) -> 
         .unwrap();
 
     for row in all {
-        let _: Uuid = row.get_by_name("my_uuid").expect("my_uuid").unwrap();
+        let _: Uuid = row.r_by_name("my_uuid").expect("my_uuid");
     }
 
     true
@@ -710,10 +682,8 @@ fn select_table_float(session: &mut Session<NoneAuthenticator, TransportTcp>) ->
         .unwrap();
 
     for row in all {
-        let _: f32 = row.get_by_name("my_float").expect("my_float").unwrap();
-        let _: f64 = row.get_by_name("my_double")
-            .expect("my_double")
-            .unwrap();
+        let _: f32 = row.r_by_name("my_float").expect("my_float");
+        let _: f64 = row.r_by_name("my_double").expect("my_double");
     }
 
     true
@@ -750,7 +720,7 @@ fn select_table_blob(session: &mut Session<NoneAuthenticator, TransportTcp>) -> 
         .unwrap();
 
     for row in all {
-        let _: Vec<u8> = row.get_by_name("my_blob").expect("my_blob").unwrap();
+        let _: Vec<u8> = row.r_by_name("my_blob").expect("my_blob");
     }
 
     true
@@ -792,9 +762,7 @@ fn select_table_timestamp(session: &mut Session<NoneAuthenticator, TransportTcp>
         .unwrap();
 
     for row in all {
-        let timestamp: time::Timespec = row.get_by_name("my_timestamp")
-            .expect("my_timestamp")
-            .unwrap();
+        let timestamp: time::Timespec = row.r_by_name("my_timestamp").expect("my_timestamp");
         assert_eq!(timestamp,
                    time::Timespec {
                        sec: 1491938018,


### PR DESCRIPTION
Fixes #111 

**Breaking changes**:

Before:

```rust
pub trait AsRustType<T> {
    fn as_rust_type(&self) -> CDRSResult<T>;
}

pub trait AsRust {
    fn as_rust<R>(&self) -> CDRSResult<R> where Self: AsRustType<R>;
}

pub trait IntoRustByName<R> {
    fn get_by_name(&self, name: &str) -> Option<CDRSResult<R>>;
}

pub trait ByName {
    fn by_name<R>(&self, name: &str) -> Option<CDRSResult<R>> where Self: IntoRustByName<R>;
}
```

**After**:
```rust
pub trait AsRustType<T> {
    fn as_rust_type(&self) -> CDRSResult<Option<T>>;
    // NEW: as non-optional Rust type
    fn as_r_type(&self) -> CDRSResult<T>;
}

pub trait AsRust {
    fn as_rust<R>(&self) -> CDRSResult<Option<R>> where Self: AsRustType<R>;
    // NEW: as non-optional Rust type
    fn as_r_rust<T>(&self) -> CDRSResult<T> where Self: AsRustType<T>;
}

/// Should be used to return a single column as Rust value by its name.
pub trait IntoRustByName<R> {
    fn get_by_name(&self, name: &str) -> CDRSResult<Option<R>>;
    // NEW: get non-options value
    fn get_r_by_name(&self, name: &str) -> CDRSResult<R>;
}

pub trait ByName {
    fn by_name<R>(&self, name: &str) -> CDRSResult<Option<R>> where Self: IntoRustByName<R>;
    // NEW: get non-optional value
    fn r_by_name<R>(&self, name: &str) -> CDRSResult<R> where Self: IntoRustByName<R>;
}
```