### PR TITLE
Disable v5 feature until it's implemented

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ default = ["v4"]
 ssl = ["openssl"]
 v3 = []
 v4 = []
-v5 = []
+# enable v5 feature when it's actually implemented
+# v5 = []
 
 [dependencies]
 byteorder = "0.5.3"


### PR DESCRIPTION
`v5` feature is temporary disabled as version 5 protocol is in beta.

Probably it makes sense to start its development when the protocol is stable.