### PR TITLE
Use a RefCell to provide external immutability for Session

### DIFF
--- a/examples/batch_queries.rs
+++ b/examples/batch_queries.rs
@@ -20,7 +20,7 @@ fn main() {
     let authenticator = PasswordAuthenticator::new(_USER, _PASS);
     let tcp_transport = TransportTcp::new(_ADDR).unwrap();
     let client = CDRS::new(tcp_transport, authenticator);
-    let mut session = client.start(Compression::None).unwrap();
+    let session = client.start(Compression::None).unwrap();
 
     let prepare_query = "INSERT INTO keyspace.integers (integer) VALUES (1);".to_string();
     let with_tracing = false;

--- a/examples/cluster.rs
+++ b/examples/cluster.rs
@@ -35,7 +35,7 @@ fn main() {
 
         thread::spawn(move || {
             let query = QueryBuilder::new("SELECT * FROM system.peers;").finalize();
-            let mut conn = pool.get().unwrap();
+            let conn = pool.get().unwrap();
             let res = if conn.query(query, false, false).is_ok() {
                 format!("Thread #{} - ok", i)
             } else {

--- a/examples/connection_pool.rs
+++ b/examples/connection_pool.rs
@@ -29,7 +29,7 @@ fn main() {
 
         thread::spawn(move || {
             let query = QueryBuilder::new("SELECT * FROM system.peers;").finalize();
-            let mut conn = pool.get().unwrap();
+            let conn = pool.get().unwrap();
             let res = if conn.query(query, false, false).is_ok() {
                 format!("Thread #{} - ok", i)
             } else {

--- a/examples/create_table.rs
+++ b/examples/create_table.rs
@@ -17,7 +17,7 @@ fn main() {
     let authenticator = PasswordAuthenticator::new(_USER, _PASS);
     let tcp_transport = TransportTcp::new(_ADDR).unwrap();
     let client = CDRS::new(tcp_transport, authenticator);
-    let mut session = client.start(Compression::None).unwrap();
+    let session = client.start(Compression::None).unwrap();
 
     // NOTE: keyspace "keyspace" should already exist
     let create_table_cql = "CREATE TABLE keyspace.users (

--- a/examples/prepare_execute.rs
+++ b/examples/prepare_execute.rs
@@ -17,7 +17,7 @@ fn main() {
     let authenticator = PasswordAuthenticator::new(_USER, _PASS);
     let tcp_transport = TransportTcp::new(_ADDR).unwrap();
     let client = CDRS::new(tcp_transport, authenticator);
-    let mut session = client.start(Compression::None).unwrap();
+    let session = client.start(Compression::None).unwrap();
 
     // NOTE: keyspace "keyspace" should already exist
     let create_table_cql = "USE keyspace;".to_string();

--- a/examples/read_table_into_struct.rs
+++ b/examples/read_table_into_struct.rs
@@ -52,7 +52,7 @@ fn main() {
     let select_query = QueryBuilder::new("SELECT * FROM my_namespace.emp;").finalize();
 
     match client.start(Compression::None) {
-        Ok(mut session) => {
+        Ok(session) => {
             let with_tracing = false;
             let with_warnings = false;
             let query_op = session.query(select_query, with_tracing, with_warnings);

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -52,7 +52,7 @@ fn main() {
     let select_query = QueryBuilder::new("SELECT * FROM my_namespace.emp;").finalize();
 
     match client.start(Compression::None) {
-        Ok(mut session) => {
+        Ok(session) => {
             let with_tracing = false;
             let with_warnings = false;
             let query_op = session.query(select_query, with_tracing, with_warnings);

--- a/examples/simple_with_auth.rs
+++ b/examples/simple_with_auth.rs
@@ -18,7 +18,7 @@ fn main() {
     let select_query = QueryBuilder::new("SELECT * FROM my_namespace.emp;").finalize();
 
     match client.start(Compression::None) {
-        Ok(mut session) => {
+        Ok(session) => {
             let with_tracing = false;
             let with_warnings = false;
             let query_op = session.query(select_query, with_tracing, with_warnings);

--- a/src/client.rs
+++ b/src/client.rs
@@ -129,33 +129,29 @@ impl<'a, T: Authenticator + 'a, X: CDRSTransport + 'a> CDRS<T, X> {
 }
 
 /// The object that provides functionality for communication with Cassandra server.
-pub struct Session<T: Authenticator, X: CDRSTransport> {
-    session: RefCell<InternalSession<T, X>>
-}
+pub struct Session<T: Authenticator, X: CDRSTransport>(RefCell<InternalSession<T, X>>);
 
 impl <T: Authenticator, X: CDRSTransport> Session<T, X> {
      /// Creates new session basing on CDRS instance.
     pub fn start(cdrs: CDRS<T, X>) -> Session<T, X> {
-        Session {
-            session: RefCell::new(InternalSession::start(cdrs)),
-        }
+        Session(RefCell::new(InternalSession::start(cdrs)))
     }
 
     /// The method overrides a compression method of current session
     pub fn compressor(&self, compressor: Compression) -> &Self {
-        self.session.borrow_mut().compressor(compressor);
+        self.0.borrow_mut().compressor(compressor);
         self
     }
 
     /// Manually ends current session.
     /// Apart of that session will be ended automatically when the instance is dropped.
     pub fn end(&self) {
-        self.session.borrow_mut().end();
+        self.0.borrow_mut().end();
     }
 
     /// The method returns `true` if underlying connection is still alive, and `false` otherwise.
     pub fn is_connected(&self) -> bool {
-        self.session.borrow().is_connected()
+        self.0.borrow().is_connected()
     }
 
     /// The method makes a request to DB Server to prepare provided query.
@@ -164,7 +160,7 @@ impl <T: Authenticator, X: CDRSTransport> Session<T, X> {
                    with_tracing: bool,
                    with_warnings: bool)
                    -> error::Result<Frame> {
-        self.session.borrow_mut().prepare(query, with_tracing, with_warnings)
+        self.0.borrow_mut().prepare(query, with_tracing, with_warnings)
     }
 
     /// The method makes a request to DB Server to execute a query with provided id
@@ -176,7 +172,7 @@ impl <T: Authenticator, X: CDRSTransport> Session<T, X> {
                    with_tracing: bool,
                    with_warnings: bool)
                    -> error::Result<Frame> {
-        self.session.borrow_mut().execute(id, query_parameters, with_tracing, with_warnings)
+        self.0.borrow_mut().execute(id, query_parameters, with_tracing, with_warnings)
     }
 
     /// The method makes a request to DB Server to execute a query provided in `query` argument.
@@ -193,7 +189,7 @@ impl <T: Authenticator, X: CDRSTransport> Session<T, X> {
                  with_tracing: bool,
                  with_warnings: bool)
                  -> error::Result<Frame> {
-        self.session.borrow_mut().query(query, with_tracing, with_warnings)
+        self.0.borrow_mut().query(query, with_tracing, with_warnings)
     }
 
     pub fn batch(&self,
@@ -201,14 +197,14 @@ impl <T: Authenticator, X: CDRSTransport> Session<T, X> {
                  with_tracing: bool,
                  with_warnings: bool)
                  -> error::Result<Frame> {
-        self.session.borrow_mut().batch(batch_query, with_tracing, with_warnings)
+        self.0.borrow_mut().batch(batch_query, with_tracing, with_warnings)
     }
 
     /// It consumes CDRS
     pub fn listen_for<'a>(self,
                           events: Vec<SimpleServerEvent>)
                           -> error::Result<(Listener<X>, EventStream)> {
-        self.session.into_inner().listen_for(events)
+        self.0.into_inner().listen_for(events)
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -128,6 +128,7 @@ impl<'a, T: Authenticator + 'a, X: CDRSTransport + 'a> CDRS<T, X> {
     }
 }
 
+/// The object that provides functionality for communication with Cassandra server.
 pub struct Session<T: Authenticator, X: CDRSTransport> {
     session: RefCell<InternalSession<T, X>>
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,7 @@
 //! The modules which contains CDRS Cassandra client.
 use std::net;
 use std::io;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use query::{Query, QueryBatch, QueryParams};
 use frame::{Flag, Frame, Opcode};
@@ -127,18 +128,101 @@ impl<'a, T: Authenticator + 'a, X: CDRSTransport + 'a> CDRS<T, X> {
     }
 }
 
-/// The object that provides functionality for communication with Cassandra server.
 pub struct Session<T: Authenticator, X: CDRSTransport> {
+    session: RefCell<InternalSession<T, X>>
+}
+
+impl <T: Authenticator, X: CDRSTransport> Session<T, X> {
+     /// Creates new session basing on CDRS instance.
+    pub fn start(cdrs: CDRS<T, X>) -> Session<T, X> {
+        Session {
+            session: RefCell::new(InternalSession::start(cdrs)),
+        }
+    }
+
+    /// The method overrides a compression method of current session
+    pub fn compressor(&self, compressor: Compression) -> &Self {
+        self.session.borrow_mut().compressor(compressor);
+        self
+    }
+
+    /// Manually ends current session.
+    /// Apart of that session will be ended automatically when the instance is dropped.
+    pub fn end(&self) {
+        self.session.borrow_mut().end();
+    }
+
+    /// The method returns `true` if underlying connection is still alive, and `false` otherwise.
+    pub fn is_connected(&self) -> bool {
+        self.session.borrow().is_connected()
+    }
+
+    /// The method makes a request to DB Server to prepare provided query.
+    pub fn prepare(&self,
+                   query: String,
+                   with_tracing: bool,
+                   with_warnings: bool)
+                   -> error::Result<Frame> {
+        self.session.borrow_mut().prepare(query, with_tracing, with_warnings)
+    }
+
+    /// The method makes a request to DB Server to execute a query with provided id
+    /// using provided query parameters. `id` is an ID of a query which Server
+    /// returns back to a driver as a response to `prepare` request.
+    pub fn execute(&self,
+                   id: &CBytesShort,
+                   query_parameters: QueryParams,
+                   with_tracing: bool,
+                   with_warnings: bool)
+                   -> error::Result<Frame> {
+        self.session.borrow_mut().execute(id, query_parameters, with_tracing, with_warnings)
+    }
+
+    /// The method makes a request to DB Server to execute a query provided in `query` argument.
+    /// you can build the query with QueryBuilder
+    /// ```
+    /// use cdrs::query::QueryBuilder;
+    /// use cdrs::compression::Compression;
+    /// use cdrs::consistency::Consistency;
+    ///
+    ///   let select_query = QueryBuilder::new("select * from emp").finalize();
+    /// ```
+    pub fn query(&self,
+                 query: Query,
+                 with_tracing: bool,
+                 with_warnings: bool)
+                 -> error::Result<Frame> {
+        self.session.borrow_mut().query(query, with_tracing, with_warnings)
+    }
+
+    pub fn batch(&self,
+                 batch_query: QueryBatch,
+                 with_tracing: bool,
+                 with_warnings: bool)
+                 -> error::Result<Frame> {
+        self.session.borrow_mut().batch(batch_query, with_tracing, with_warnings)
+    }
+
+    /// It consumes CDRS
+    pub fn listen_for<'a>(self,
+                          events: Vec<SimpleServerEvent>)
+                          -> error::Result<(Listener<X>, EventStream)> {
+        self.session.into_inner().listen_for(events)
+    }
+}
+
+/// The object that provides functionality for communication with Cassandra server.
+struct InternalSession<T: Authenticator, X: CDRSTransport> {
     started: bool,
     cdrs: CDRS<T, X>,
     compressor: Compression,
 }
 
-impl<T: Authenticator, X: CDRSTransport> Session<T, X> {
+impl<T: Authenticator, X: CDRSTransport> InternalSession<T, X> {
     /// Creates new session basing on CDRS instance.
-    pub fn start(cdrs: CDRS<T, X>) -> Session<T, X> {
+    pub fn start(cdrs: CDRS<T, X>) -> InternalSession<T, X> {
         let compressor = cdrs.compressor.clone();
-        Session { cdrs: cdrs,
+        InternalSession { cdrs: cdrs,
                   started: true,
                   compressor: compressor, }
     }

--- a/tests/collection_types.rs
+++ b/tests/collection_types.rs
@@ -27,7 +27,7 @@ fn list() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_lists \
                (my_text_list frozen<list<text>> PRIMARY KEY, \
                my_nested_list list<frozen<list<int>>>)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     let my_text_list = vec!["text1".to_string(),
                             "text2".to_string(),
@@ -80,7 +80,7 @@ fn list_v4() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_lists_v4 \
                (my_text_list frozen<list<text>> PRIMARY KEY, \
                my_nested_list list<frozen<list<smallint>>>)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     let my_text_list = vec!["text1".to_string(),
                             "text2".to_string(),
@@ -132,7 +132,7 @@ fn set() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_sets \
                (my_text_set frozen<set<text>> PRIMARY KEY, \
                my_nested_set set<frozen<set<int>>>)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     let my_text_set = vec!["text1".to_string(),
                            "text2".to_string(),
@@ -185,7 +185,7 @@ fn set_v4() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_sets_v4 \
                (my_text_set frozen<set<text>> PRIMARY KEY, \
                my_nested_set set<frozen<set<smallint>>>)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     let my_text_set = vec!["text1".to_string(),
                            "text2".to_string(),
@@ -238,7 +238,7 @@ fn map_without_blob() {
                (my_key int PRIMARY KEY, \
                my_text_map map<text, text>, \
                my_nested_map map<uuid, frozen<map<bigint, int>>>)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     let my_text_map = hashmap!{
         "key1".to_string() => "value1".to_string(),
@@ -307,7 +307,7 @@ fn map_without_blob_v4() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_maps_without_blob_v4 \
                (my_text_map frozen<map<text, text>> PRIMARY KEY, \
                my_nested_map map<uuid, frozen<map<bigint, tinyint>>>)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     let my_text_map = hashmap!{
         "key1".to_string() => "value1".to_string(),
@@ -373,7 +373,7 @@ fn map() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_maps \
                (my_text_map frozen<map<text, text>> PRIMARY KEY, \
                my_nested_map map<uuid, frozen<map<bigint, blob>>>)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     let my_text_map = hashmap!{
         "key1".to_string() => "value1".to_string(),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -18,7 +18,7 @@ pub fn setup_multiple(create_cqls: &[&'static str]) -> Result<CSession> {
     let authenticator = NoneAuthenticator;
     let tcp_transport = TransportTcp::new(ADDR)?;
     let client = CDRS::new(tcp_transport, authenticator);
-    let mut session = client.start(Compression::None)?;
+    let session = client.start(Compression::None)?;
     let re_table_name = Regex::new(r"CREATE TABLE IF NOT EXISTS (\w+\.\w+)").unwrap();
 
     let cql = "CREATE KEYSPACE IF NOT EXISTS cdrs_test WITH \

--- a/tests/create_insert_table.rs
+++ b/tests/create_insert_table.rs
@@ -82,7 +82,7 @@ fn teardown() {
 fn insert_data_users() {
     println!("insert_data_users");
     let ctx = TestContext::new();
-    let mut session = ctx.client.start(Compression::None).unwrap();
+    let session = ctx.client.start(Compression::None).unwrap();
     let insert_table_cql = "INSERT INTO user_keyspace.users
             (user_name, password, gender, session_token, state)
     VALUES (?, ?, ?, ?, ?)";
@@ -113,7 +113,7 @@ fn insert_data_users() {
 fn read_from_user_table() {
     println!("read_from_user_table");
     let ctx = TestContext::new();
-    let mut session = ctx.client.start(Compression::None).unwrap();
+    let session = ctx.client.start(Compression::None).unwrap();
     let select_query = QueryBuilder::new(
         "\
         SELECT user_name, password, gender, session_token, state, some_map \
@@ -183,7 +183,7 @@ impl TestContext {
 
 fn create_keyspace() {
     let ctx = TestContext::new();
-    let mut session = ctx.client.start(Compression::None).unwrap();
+    let session = ctx.client.start(Compression::None).unwrap();
     let create_ks_cql = "CREATE KEYSPACE IF NOT EXISTS user_keyspace WITH REPLICATION = { 'class' \
                          : 'SimpleStrategy', 'replication_factor' : 1 } ;";
 
@@ -198,7 +198,7 @@ fn create_keyspace() {
 
 fn create_table() {
     let ctx = TestContext::new();
-    let mut session = ctx.client.start(Compression::None).unwrap();
+    let session = ctx.client.start(Compression::None).unwrap();
     let create_table_cql = "CREATE TABLE IF NOT EXISTS user_keyspace.users (
         user_name varchar PRIMARY KEY,
         password varchar,
@@ -224,7 +224,7 @@ fn create_table() {
 
 fn drop_keyspace() {
     let ctx = TestContext::new();
-    let mut session = ctx.client.start(Compression::None).unwrap();
+    let session = ctx.client.start(Compression::None).unwrap();
     let drop_ks = "DROP KEYSPACE IF EXISTS user_keyspace;";
     let with_tracing = false;
     let with_warnings = false;

--- a/tests/keyspace.rs
+++ b/tests/keyspace.rs
@@ -20,7 +20,7 @@ fn create_keyspace() {
         let authenticator = NoneAuthenticator;
         let tcp_transport = TransportTcp::new(ADDR).expect("create transport");
         let client = CDRS::new(tcp_transport, authenticator);
-        let mut session = client.start(Compression::None).expect("start session");
+        let session = client.start(Compression::None).expect("start session");
 
         let drop_ks_cql = "DROP KEYSPACE IF EXISTS create_ks_test";
         let drop_query = QueryBuilder::new(drop_ks_cql).finalize();
@@ -79,7 +79,7 @@ fn alter_keyspace() {
         let authenticator = NoneAuthenticator;
         let tcp_transport = TransportTcp::new(ADDR).expect("create transport");
         let client = CDRS::new(tcp_transport, authenticator);
-        let mut session = client.start(Compression::None).expect("start session");
+        let session = client.start(Compression::None).expect("start session");
 
         let drop_ks_cql = "DROP KEYSPACE IF EXISTS alter_ks_test";
         let drop_query = QueryBuilder::new(drop_ks_cql).finalize();
@@ -132,7 +132,7 @@ fn use_keyspace() {
         let authenticator = NoneAuthenticator;
         let tcp_transport = TransportTcp::new(ADDR).expect("create transport");
         let client = CDRS::new(tcp_transport, authenticator);
-        let mut session = client.start(Compression::None).expect("start session");
+        let session = client.start(Compression::None).expect("start session");
 
         let create_ks_cql = "CREATE KEYSPACE IF NOT EXISTS use_ks_test WITH \
                              replication = {'class': 'SimpleStrategy', 'replication_factor': 1} \
@@ -161,7 +161,7 @@ fn drop_keyspace() {
         let authenticator = NoneAuthenticator;
         let tcp_transport = TransportTcp::new(ADDR).expect("create transport");
         let client = CDRS::new(tcp_transport, authenticator);
-        let mut session = client.start(Compression::None).expect("start session");
+        let session = client.start(Compression::None).expect("start session");
 
         let create_ks_cql = "CREATE KEYSPACE IF NOT EXISTS drop_ks_test WITH \
                              replication = {'class': 'SimpleStrategy', 'replication_factor': 1} \

--- a/tests/native_types.rs
+++ b/tests/native_types.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 fn string() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_string \
                (my_ascii ascii PRIMARY KEY, my_text text, my_varchar varchar)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     let my_ascii = "my_ascii".to_string();
     let my_text = "my_text".to_string();
@@ -64,7 +64,7 @@ fn string() {
 fn counter() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_counter \
                (my_bigint bigint PRIMARY KEY, my_counter counter)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     let my_bigint: i64 = 10_000_000_000_000_000;
     let my_counter: i64 = 100_000_000;
@@ -100,7 +100,7 @@ fn counter() {
 fn integer() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_integer \
                (my_bigint bigint PRIMARY KEY, my_int int, my_boolean boolean)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     let my_bigint: i64 = 10_000_000_000_000_000;
     let my_int: i32 = 100_000_000;
@@ -141,7 +141,7 @@ fn integer_v4() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_integer_v4 \
                (my_bigint bigint PRIMARY KEY, my_int int, my_smallint smallint, \
                my_tinyint tinyint, my_boolean boolean)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     let my_bigint: i64 = 10_000_000_000_000_000;
     let my_int: i32 = 100_000_000;
@@ -190,7 +190,7 @@ fn integer_v4() {
 fn float() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_float \
                (my_float float PRIMARY KEY, my_double double)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     let my_float: f32 = 123.456;
     let my_double: f64 = 987.654;
@@ -224,7 +224,7 @@ fn float() {
 fn blob() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_blob \
                (my_blob blob PRIMARY KEY, my_mapblob map<text, blob>)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     let my_blob: Blob = vec![0, 1, 2, 4, 8, 16, 32, 64, 128, 255].into();
     let my_map: HashMap<String, Blob> = [("a".to_owned(), b"aaaaa".to_vec().into()),
@@ -274,7 +274,7 @@ fn blob() {
 fn uuid() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_uuid \
                (my_uuid uuid PRIMARY KEY)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     let my_uuid = Uuid::from_str("bb16106a-10bc-4a07-baa3-126ffe208c43").unwrap();
     let values: Vec<Value> = vec![my_uuid.into()];
@@ -306,7 +306,7 @@ fn uuid() {
 fn time() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_time \
                (my_timestamp timestamp PRIMARY KEY)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     let my_timestamp = time::get_time();
     let values: Vec<Value> = vec![my_timestamp.into()];
@@ -340,7 +340,7 @@ fn time() {
 fn inet() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_inet \
                (my_inet_v4 inet PRIMARY KEY, my_inet_v6 inet)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     let my_inet_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let my_inet_v6 = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));

--- a/tests/simple_connect.rs
+++ b/tests/simple_connect.rs
@@ -21,7 +21,7 @@ fn connect_to_cassandra() {
     assert_eq!(tcp_transport.is_ok(), true);
 
     let client = CDRS::new(tcp_transport.unwrap(), authenticator);
-    let mut session = client.start(Compression::None).unwrap();
+    let session = client.start(Compression::None).unwrap();
 
     let select_peers = "SELECT peer,data_center,rack,tokens,rpc_address,release_version FROM \
                         system.peers";

--- a/tests/tuple_types.rs
+++ b/tests/tuple_types.rs
@@ -25,7 +25,7 @@ use std::str::FromStr;
 fn simple_tuple() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.simple_tuple \
                (my_tuple tuple<text, int> PRIMARY KEY)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     #[derive(Debug, Clone, PartialEq)]
     struct MyTuple {
@@ -86,7 +86,7 @@ fn nested_tuples() {
     let cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_nested_tuples \
                (my_key int PRIMARY KEY, \
                my_outer_tuple tuple<uuid, blob, tuple<text, int, timestamp>>)";
-    let mut session = setup(cql).expect("setup");
+    let session = setup(cql).expect("setup");
 
     #[derive(Debug, Clone, PartialEq)]
     struct MyInnerTuple {

--- a/tests/user_defined_types.rs
+++ b/tests/user_defined_types.rs
@@ -26,7 +26,7 @@ fn simple_udt() {
     let create_type_cql = "CREATE TYPE IF NOT EXISTS cdrs_test.simple_udt (my_text text)";
     let create_table_cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_simple_udt \
                             (my_key int PRIMARY KEY, my_udt simple_udt)";
-    let mut session = setup_multiple(&[create_type_cql, create_table_cql]).expect("setup");
+    let session = setup_multiple(&[create_type_cql, create_table_cql]).expect("setup");
 
     #[derive(Debug, Clone, PartialEq)]
     struct MyUdt {
@@ -85,7 +85,7 @@ fn nested_udt() {
                             (my_inner_udt frozen<nested_inner_udt>)";
     let create_table_cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_nested_udt \
                             (my_key int PRIMARY KEY, my_outer_udt nested_outer_udt)";
-    let mut session =
+    let session =
         setup_multiple(&[create_type1_cql, create_type2_cql, create_table_cql]).expect("setup");
 
     #[derive(Debug, Clone, PartialEq)]
@@ -172,7 +172,7 @@ fn alter_udt_add() {
     let create_type_cql = "CREATE TYPE cdrs_test.alter_udt_add_udt (my_text text)";
     let create_table_cql = "CREATE TABLE IF NOT EXISTS cdrs_test.test_alter_udt_add \
                             (my_key int PRIMARY KEY, my_map frozen<map<text, alter_udt_add_udt>>)";
-    let mut session = setup_multiple(&[drop_table_cql,
+    let session = setup_multiple(&[drop_table_cql,
                                        drop_type_cql,
                                        create_type_cql,
                                        create_table_cql])


### PR DESCRIPTION
As the title says this renames Session to InternalSession, then provides a RefCell wrapper for Session that allows for external mutability. This allows, much like the postgres crate, an immutable shared reference to be used by crate users.

For comparison:
https://github.com/sfackler/rust-postgres/blob/master/postgres/src/lib.rs#L951

This fixes #201 

Notably when running tests or compiling code rustc will warn about not needing mut anymore, but no breaking changes are required for this!