### PR TITLE
Updating uuid to 0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ r2d2 = "0.8.2"
 rand = "0.4.1"
 snap = "0.2.3"
 time = "0.1.38"
-uuid = "0.5.1"
+uuid = "0.6.1"
 
 [dev-dependencies]
 env_logger = "0.4.3"


### PR DESCRIPTION
Hey

Updating this crate to 0.6 since the new release is out. There are no further changes required.