### PR TITLE
Update uuid to 0.7

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@ List of contributors:
 * j4in
 * ernestas-poskus
 * dfaust
+* Dylan DPC

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ r2d2 = "0.8.2"
 rand = "0.4.1"
 snap = "0.2.3"
 time = "0.1.38"
-uuid = "0.6.3"
+uuid = "0.7"
 
 [dev-dependencies]
 env_logger = "0.4.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use std::string::FromUtf8Error;
 use std::fmt::Display;
 use frame::frame_error::CDRSError;
 use compression::CompressionError;
-use uuid::ParseError;
+use uuid::parser::ParseError;
 
 pub type Result<T> = result::Result<T, Error>;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use std::string::FromUtf8Error;
 use std::fmt::Display;
 use frame::frame_error::CDRSError;
 use compression::CompressionError;
-use uuid::parser::ParseError;
+use uuid::BytesError;
 
 pub type Result<T> = result::Result<T, Error>;
 
@@ -20,7 +20,7 @@ pub enum Error {
     /// Internal IO error.
     Io(io::Error),
     /// Internal error that may be raised during `uuid::Uuid::from_bytes`
-    UUIDParse(ParseError),
+    UUIDParse(BytesError),
     /// General error
     General(String),
     /// Internal error that may be raised during `String::from_utf8`
@@ -86,8 +86,8 @@ impl From<FromUtf8Error> for Error {
     }
 }
 
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Error {
+impl From<BytesError> for Error {
+    fn from(err: BytesError) -> Error {
         Error::UUIDParse(err)
     }
 }

--- a/src/types/data_serialization_types.rs
+++ b/src/types/data_serialization_types.rs
@@ -189,9 +189,9 @@ pub fn decode_time(bytes: &[u8]) -> Result<i64, io::Error> {
     try_i_from_bytes(bytes)
 }
 
-// Decodes Cassandra `timeuuid` data (bytes) into Rust's `Result<uuid::Uuid, uuid::ParseError>`
-pub fn decode_timeuuid(bytes: &[u8]) -> Result<uuid::Uuid, uuid::ParseError> {
-    uuid::Uuid::from_bytes(bytes)
+// Decodes Cassandra `timeuuid` data (bytes) into Rust's `Result<uuid::Uuid, uuid::BytesError>`
+pub fn decode_timeuuid(bytes: &[u8]) -> Result<uuid::Uuid, uuid::BytesError> {
+    uuid::Uuid::from_slice(bytes)
 }
 
 // Decodes Cassandra `varint` data (bytes) into Rust's `Result<i64, io::Error>`


### PR DESCRIPTION
This updates uuid to 0.7.

The release contains some breaking changes and those have changes have been made for this crate. 

This is a breaking change for your crate and luckilly found this before you issued a major 2.0 stable release :smile: 