### PR TITLE
Switch to blocking mutex lock

### DIFF
--- a/src/load_balancing/mod.rs
+++ b/src/load_balancing/mod.rs
@@ -1,10 +1,12 @@
 mod random;
 mod round_robin;
 mod round_robin_sync;
+mod single_node;
 
 pub use load_balancing::random::Random;
 pub use load_balancing::round_robin::RoundRobin;
 pub use load_balancing::round_robin_sync::RoundRobinSync;
+pub use load_balancing::single_node::SingleNode;
 
 pub trait LoadBalancingStrategy<N>: Sized {
   fn init(&mut self, cluster: Vec<N>);

--- a/src/load_balancing/round_robin_sync.rs
+++ b/src/load_balancing/round_robin_sync.rs
@@ -32,7 +32,7 @@ impl<N> LoadBalancingStrategy<N> for RoundRobinSync<N> {
 
   /// Returns next node from a cluster
   fn next(&self) -> Option<&N> {
-    let mut prev_idx = self.prev_idx.try_lock();
+    let mut prev_idx = self.prev_idx.lock();
     if let Ok(ref mut mtx) = prev_idx {
       let next_idx = (**mtx + 1) % self.cluster.len();
       **mtx = next_idx;

--- a/src/load_balancing/single_node.rs
+++ b/src/load_balancing/single_node.rs
@@ -1,0 +1,45 @@
+use super::LoadBalancingStrategy;
+
+pub struct SingleNode<N> {
+  cluster: Vec<N>
+}
+
+impl<N> SingleNode<N> {
+  pub fn new() -> Self {
+    SingleNode {
+      cluster: vec![]
+    }
+  }
+}
+
+impl<N> From<Vec<N>> for SingleNode<N> {
+  fn from(cluster: Vec<N>) -> SingleNode<N> {
+    SingleNode {
+      cluster: cluster,
+    }
+  }
+}
+
+impl<N> LoadBalancingStrategy<N> for SingleNode<N> {
+  fn init(&mut self, cluster: Vec<N>) {
+    self.cluster = cluster;
+  }
+
+  /// Returns first node from cluster
+  fn next(&self) -> Option<&N> {
+    self.cluster.get(0)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn single_node() {
+    let nodes = vec!["a"];
+    let nodes_c = nodes.clone();
+    let load_balancer = SingleNode::from(nodes);
+    assert_eq!(&nodes_c[0], load_balancer.next().unwrap());
+  }
+}


### PR DESCRIPTION
Switch to a blocking mutex lock to prevent "Unable to ge transport" error in multi threaded applications.
references issue #230