### PR TITLE
Add possibility to clone Row

### DIFF
--- a/src/types/rows.rs
+++ b/src/types/rows.rs
@@ -15,7 +15,7 @@ use types::tuple::Tuple;
 use types::udt::UDT;
 use types::{ByIndex, ByName, CBytes, IntoRustByIndex, IntoRustByName};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Row {
     metadata: RowsMetadata,
     row_content: Vec<CBytes>,


### PR DESCRIPTION
Needed to take some vector element without breaking an vector of rows
(also needed since `try_from_row` method can't work with refs)

(also please tell if there is any communication channel, I had few additional questions)