### PR TITLE
Pager for stateless executions

### DIFF
--- a/examples/paged_query.rs
+++ b/examples/paged_query.rs
@@ -5,7 +5,7 @@ extern crate cdrs_helpers_derive;
 
 use cdrs::authenticators::NoneAuthenticator;
 use cdrs::cluster::session::{new as new_session, Session};
-use cdrs::cluster::{ClusterTcpConfig, NodeTcpConfigBuilder, TcpConnectionPool};
+use cdrs::cluster::{ClusterTcpConfig, NodeTcpConfigBuilder, TcpConnectionPool, PagerState};
 use cdrs::load_balancing::RoundRobin;
 use cdrs::query::*;
 
@@ -38,7 +38,7 @@ fn main() {
   println!("Internal pager state\n");
   paged_selection_query(&no_compression);
   println!("\n\nExternal pager state for stateless executions\n");
-  paged_selection_query_with_state(&no_compression, None)
+  paged_selection_query_with_state(&no_compression, PagerState::new());
 }
 
 fn create_keyspace(session: &CurrentSession) {
@@ -87,15 +87,13 @@ fn paged_selection_query(session: &CurrentSession) {
 }
 
 
-fn paged_selection_query_with_state(session: &CurrentSession, state: Option<String>) {
+fn paged_selection_query_with_state(session: &CurrentSession, state: PagerState) {
   let mut st = state;
 
   loop {
-
     let q = "SELECT * FROM test_ks.my_test_table;";
     let mut pager = session.paged(2);
-    let mut query_pager = pager.query_with_pager_state(q, st).unwrap();
-
+    let mut query_pager = pager.query_with_pager_state(q, st);
 
     let rows = query_pager.next().expect("pager next");
     for row in rows {

--- a/examples/paged_query.rs
+++ b/examples/paged_query.rs
@@ -17,91 +17,91 @@ type CurrentSession = Session<RoundRobin<TcpConnectionPool<NoneAuthenticator>>>;
 
 #[derive(Clone, Debug, IntoCDRSValue, TryFromRow, PartialEq)]
 struct RowStruct {
-    key: i32,
+  key: i32,
 }
 
 impl RowStruct {
-    fn into_query_values(self) -> QueryValues {
-        query_values!("key" => self.key)
-    }
+  fn into_query_values(self) -> QueryValues {
+    query_values!("key" => self.key)
+  }
 }
 
 fn main() {
-    let node = NodeTcpConfigBuilder::new("127.0.0.1:9042", NoneAuthenticator {}).build();
-    let cluster_config = ClusterTcpConfig(vec![node]);
-    let lb = RoundRobin::new();
-    let no_compression = new_session(&cluster_config, lb).expect("session should be created");
+  let node = NodeTcpConfigBuilder::new("127.0.0.1:9042", NoneAuthenticator {}).build();
+  let cluster_config = ClusterTcpConfig(vec![node]);
+  let lb = RoundRobin::new();
+  let no_compression = new_session(&cluster_config, lb).expect("session should be created");
 
-    create_keyspace(&no_compression);
-    create_table(&no_compression);
-    fill_table(&no_compression);
-    println!("Internal pager state\n");
-    paged_selection_query(&no_compression);
-    println!("\n\nExternal pager state for stateless executions\n");
-    paged_selection_query_with_state(&no_compression, PagerState::new());
+  create_keyspace(&no_compression);
+  create_table(&no_compression);
+  fill_table(&no_compression);
+  println!("Internal pager state\n");
+  paged_selection_query(&no_compression);
+  println!("\n\nExternal pager state for stateless executions\n");
+  paged_selection_query_with_state(&no_compression, PagerState::new());
 }
 
 fn create_keyspace(session: &CurrentSession) {
-    let create_ks: &'static str = "CREATE KEYSPACE IF NOT EXISTS test_ks WITH REPLICATION = { \
-                                   'class' : 'SimpleStrategy', 'replication_factor' : 1 };";
-    session.query(create_ks).expect("Keyspace creation error");
+  let create_ks: &'static str = "CREATE KEYSPACE IF NOT EXISTS test_ks WITH REPLICATION = { \
+                                 'class' : 'SimpleStrategy', 'replication_factor' : 1 };";
+  session.query(create_ks).expect("Keyspace creation error");
 }
 
 fn create_table(session: &CurrentSession) {
-    let create_table_cql =
-        "CREATE TABLE IF NOT EXISTS test_ks.my_test_table (key int PRIMARY KEY, \
-         user test_ks.user, map map<text, frozen<test_ks.user>>, list list<frozen<test_ks.user>>);";
-    session.query(create_table_cql)
-           .expect("Table creation error");
+  let create_table_cql =
+    "CREATE TABLE IF NOT EXISTS test_ks.my_test_table (key int PRIMARY KEY, \
+     user test_ks.user, map map<text, frozen<test_ks.user>>, list list<frozen<test_ks.user>>);";
+  session.query(create_table_cql)
+         .expect("Table creation error");
 }
 
 fn fill_table(session: &CurrentSession) {
-    let insert_struct_cql = "INSERT INTO test_ks.my_test_table (key) VALUES (?)";
+  let insert_struct_cql = "INSERT INTO test_ks.my_test_table (key) VALUES (?)";
 
-    for k in 100..110 {
-        let row = RowStruct { key: k as i32 };
+  for k in 100..110 {
+    let row = RowStruct { key: k as i32 };
 
-        session.query_with_values(insert_struct_cql, row.into_query_values())
-               .expect("insert");
-    }
+    session.query_with_values(insert_struct_cql, row.into_query_values())
+           .expect("insert");
+  }
 }
 
 fn paged_selection_query(session: &CurrentSession) {
-    let q = "SELECT * FROM test_ks.my_test_table;";
-    let mut pager = session.paged(2);
-    let mut query_pager = pager.query(q);
+  let q = "SELECT * FROM test_ks.my_test_table;";
+  let mut pager = session.paged(2);
+  let mut query_pager = pager.query(q);
 
-    loop {
-        let rows = query_pager.next().expect("pager next");
-        for row in rows {
-            let my_row = RowStruct::try_from_row(row).expect("decode row");
-            println!("row - {:?}", my_row);
-        }
-
-        if !query_pager.has_more() {
-            break;
-        }
+  loop {
+    let rows = query_pager.next().expect("pager next");
+    for row in rows {
+      let my_row = RowStruct::try_from_row(row).expect("decode row");
+      println!("row - {:?}", my_row);
     }
+
+    if !query_pager.has_more() {
+      break;
+    }
+  }
 }
 
 fn paged_selection_query_with_state(session: &CurrentSession, state: PagerState) {
-    let mut st = state;
+  let mut st = state;
 
-    loop {
-        let q = "SELECT * FROM test_ks.my_test_table;";
-        let mut pager = session.paged(2);
-        let mut query_pager = pager.query_with_pager_state(q, st);
+  loop {
+    let q = "SELECT * FROM test_ks.my_test_table;";
+    let mut pager = session.paged(2);
+    let mut query_pager = pager.query_with_pager_state(q, st);
 
-        let rows = query_pager.next().expect("pager next");
-        for row in rows {
-            let my_row = RowStruct::try_from_row(row).expect("decode row");
-            println!("row - {:?}", my_row);
-        }
-
-        if !query_pager.has_more() {
-            break;
-        }
-
-        st = query_pager.pager_state();
+    let rows = query_pager.next().expect("pager next");
+    for row in rows {
+      let my_row = RowStruct::try_from_row(row).expect("decode row");
+      println!("row - {:?}", my_row);
     }
+
+    if !query_pager.has_more() {
+      break;
+    }
+
+    st = query_pager.pager_state();
+  }
 }

--- a/examples/paged_query.rs
+++ b/examples/paged_query.rs
@@ -5,7 +5,7 @@ extern crate cdrs_helpers_derive;
 
 use cdrs::authenticators::NoneAuthenticator;
 use cdrs::cluster::session::{new as new_session, Session};
-use cdrs::cluster::{ClusterTcpConfig, NodeTcpConfigBuilder, TcpConnectionPool, PagerState};
+use cdrs::cluster::{ClusterTcpConfig, NodeTcpConfigBuilder, PagerState, TcpConnectionPool};
 use cdrs::load_balancing::RoundRobin;
 use cdrs::query::*;
 
@@ -17,94 +17,91 @@ type CurrentSession = Session<RoundRobin<TcpConnectionPool<NoneAuthenticator>>>;
 
 #[derive(Clone, Debug, IntoCDRSValue, TryFromRow, PartialEq)]
 struct RowStruct {
-  key: i32,
+    key: i32,
 }
 
 impl RowStruct {
-  fn into_query_values(self) -> QueryValues {
-    query_values!("key" => self.key)
-  }
+    fn into_query_values(self) -> QueryValues {
+        query_values!("key" => self.key)
+    }
 }
 
 fn main() {
-  let node = NodeTcpConfigBuilder::new("127.0.0.1:9042", NoneAuthenticator {}).build();
-  let cluster_config = ClusterTcpConfig(vec![node]);
-  let lb = RoundRobin::new();
-  let no_compression = new_session(&cluster_config, lb).expect("session should be created");
+    let node = NodeTcpConfigBuilder::new("127.0.0.1:9042", NoneAuthenticator {}).build();
+    let cluster_config = ClusterTcpConfig(vec![node]);
+    let lb = RoundRobin::new();
+    let no_compression = new_session(&cluster_config, lb).expect("session should be created");
 
-  create_keyspace(&no_compression);
-  create_table(&no_compression);
-  fill_table(&no_compression);
-  println!("Internal pager state\n");
-  paged_selection_query(&no_compression);
-  println!("\n\nExternal pager state for stateless executions\n");
-  paged_selection_query_with_state(&no_compression, PagerState::new());
+    create_keyspace(&no_compression);
+    create_table(&no_compression);
+    fill_table(&no_compression);
+    println!("Internal pager state\n");
+    paged_selection_query(&no_compression);
+    println!("\n\nExternal pager state for stateless executions\n");
+    paged_selection_query_with_state(&no_compression, PagerState::new());
 }
 
 fn create_keyspace(session: &CurrentSession) {
-  let create_ks: &'static str = "CREATE KEYSPACE IF NOT EXISTS test_ks WITH REPLICATION = { \
-                                 'class' : 'SimpleStrategy', 'replication_factor' : 1 };";
-  session.query(create_ks).expect("Keyspace creation error");
+    let create_ks: &'static str = "CREATE KEYSPACE IF NOT EXISTS test_ks WITH REPLICATION = { \
+                                   'class' : 'SimpleStrategy', 'replication_factor' : 1 };";
+    session.query(create_ks).expect("Keyspace creation error");
 }
 
 fn create_table(session: &CurrentSession) {
-  let create_table_cql =
-    "CREATE TABLE IF NOT EXISTS test_ks.my_test_table (key int PRIMARY KEY, \
-     user test_ks.user, map map<text, frozen<test_ks.user>>, list list<frozen<test_ks.user>>);";
-  session
-    .query(create_table_cql)
-    .expect("Table creation error");
+    let create_table_cql =
+        "CREATE TABLE IF NOT EXISTS test_ks.my_test_table (key int PRIMARY KEY, \
+         user test_ks.user, map map<text, frozen<test_ks.user>>, list list<frozen<test_ks.user>>);";
+    session.query(create_table_cql)
+           .expect("Table creation error");
 }
 
 fn fill_table(session: &CurrentSession) {
-  let insert_struct_cql = "INSERT INTO test_ks.my_test_table (key) VALUES (?)";
+    let insert_struct_cql = "INSERT INTO test_ks.my_test_table (key) VALUES (?)";
 
-  for k in 100..110 {
-    let row = RowStruct { key: k as i32 };
+    for k in 100..110 {
+        let row = RowStruct { key: k as i32 };
 
-    session
-      .query_with_values(insert_struct_cql, row.into_query_values())
-      .expect("insert");
-  }
+        session.query_with_values(insert_struct_cql, row.into_query_values())
+               .expect("insert");
+    }
 }
 
 fn paged_selection_query(session: &CurrentSession) {
-  let q = "SELECT * FROM test_ks.my_test_table;";
-  let mut pager = session.paged(2);
-  let mut query_pager = pager.query(q);
-
-  loop {
-    let rows = query_pager.next().expect("pager next");
-    for row in rows {
-      let my_row = RowStruct::try_from_row(row).expect("decode row");
-      println!("row - {:?}", my_row);
-    }
-
-    if !query_pager.has_more() {
-      break;
-    }
-  }
-}
-
-
-fn paged_selection_query_with_state(session: &CurrentSession, state: PagerState) {
-  let mut st = state;
-
-  loop {
     let q = "SELECT * FROM test_ks.my_test_table;";
     let mut pager = session.paged(2);
-    let mut query_pager = pager.query_with_pager_state(q, st);
+    let mut query_pager = pager.query(q);
 
-    let rows = query_pager.next().expect("pager next");
-    for row in rows {
-      let my_row = RowStruct::try_from_row(row).expect("decode row");
-      println!("row - {:?}", my_row);
+    loop {
+        let rows = query_pager.next().expect("pager next");
+        for row in rows {
+            let my_row = RowStruct::try_from_row(row).expect("decode row");
+            println!("row - {:?}", my_row);
+        }
+
+        if !query_pager.has_more() {
+            break;
+        }
     }
+}
 
-    if !query_pager.has_more() {
-      break;
+fn paged_selection_query_with_state(session: &CurrentSession, state: PagerState) {
+    let mut st = state;
+
+    loop {
+        let q = "SELECT * FROM test_ks.my_test_table;";
+        let mut pager = session.paged(2);
+        let mut query_pager = pager.query_with_pager_state(q, st);
+
+        let rows = query_pager.next().expect("pager next");
+        for row in rows {
+            let my_row = RowStruct::try_from_row(row).expect("decode row");
+            println!("row - {:?}", my_row);
+        }
+
+        if !query_pager.has_more() {
+            break;
+        }
+
+        st = query_pager.pager_state();
     }
-
-    st = query_pager.pager_state();
-  }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,5 @@
-indent_style = "Visual"
+indent_style = "Block"
 combine_control_expr = false
+tab_spaces = 2
+brace_style = "SameLineWhere" 
+empty_item_single_line = true

--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -13,7 +13,7 @@ mod tcp_connection_pool;
 #[cfg(feature = "ssl")]
 pub use cluster::config_ssl::{ClusterSslConfig, NodeSslConfig, NodeSslConfigBuilder};
 pub use cluster::config_tcp::{ClusterTcpConfig, NodeTcpConfig, NodeTcpConfigBuilder};
-pub use cluster::pager::{QueryPager, SessionPager};
+pub use cluster::pager::{QueryPager, SessionPager, PagerState};
 #[cfg(feature = "ssl")]
 pub use cluster::ssl_connection_pool::{new_ssl_pool, SslConnectionPool, SslConnectionsManager};
 pub use cluster::tcp_connection_pool::{

--- a/src/cluster/pager.rs
+++ b/src/cluster/pager.rs
@@ -54,7 +54,7 @@ impl<
   where
     Q: ToString,
   {
-    self.query_with_pager_state(query, PagerState { cursor : None, has_more_pages : None})
+    self.query_with_pager_state(query, PagerState::new())
   }
 
   pub fn exec_with_pager_state(&'a mut self, query: &'a PreparedQuery, state: PagerState) -> ExecPager<'a, SessionPager<'a, M, S, T>> {
@@ -66,7 +66,7 @@ impl<
   }
 
   pub fn exec(&'a mut self, query: &'a PreparedQuery) -> ExecPager<'a, SessionPager<'a, M, S, T>> {
-    self.exec_with_pager_state(query, PagerState { cursor : None, has_more_pages : None})
+    self.exec_with_pager_state(query, PagerState::new())
   }
 }
 

--- a/src/cluster/pager.rs
+++ b/src/cluster/pager.rs
@@ -39,47 +39,14 @@ impl<
     }
   }
 
-
-  /// Java native driver also uses this technique to
-  /// perform stateless pagination
-  /// (https://docs.datastax.com/en/developer/java-driver/3.2/manual/paging/)
-  pub fn query_with_pager_state<Q>(&'a mut self, query: Q, state: Option<String>) -> Result<QueryPager<'a, Q, SessionPager<'a, M, S, T>>, error::Error>
+  pub fn query_with_pager_state<Q>(&'a mut self, query: Q, state: PagerState) -> QueryPager<'a, Q, SessionPager<'a, M, S, T>>
     where
       Q: ToString,
   {
-    let tmp_state: Option<Result<Option<CBytes>, &str>> = state
-      .map(|st| {
-        if st.is_empty() || st.len() % 3 != 0 {
-          return Ok(None);
-        }
-
-        let cap: usize = st.len() / 3;
-
-        let mut vec: Vec<u8> = Vec::with_capacity(cap);
-
-        let mut p = st.chars().peekable();
-
-        while p.peek().is_some() {
-          let chunk: String = p.by_ref().take(3).collect();
-          vec.push(chunk.parse::<u8>().map_err(|_p_err| "String must be composed by digits")?);
-        }
-
-        Ok(Some(CBytes::new(vec)))
-      });
-
-    match tmp_state {
-      Some(r_state) => match r_state {
-        Ok(s_state) => {
-          Ok(QueryPager {
-            pager: self,
-            paging_state: s_state,
-            has_more_pages: None,
-            query,
-          })
-        }
-        Err(err) => Err(error::Error::General(err.to_string()))
-      },
-      None => Ok(self.query(query)),
+    QueryPager {
+      pager: self,
+      pager_state : state,
+      query,
     }
   }
 
@@ -89,8 +56,15 @@ impl<
   {
     QueryPager {
       pager: self,
-      paging_state: None,
-      has_more_pages: None,
+      pager_state: PagerState { cursor : None, has_more_pages : None},
+      query,
+    }
+  }
+
+  pub fn exec_with_pager_state(&'a mut self, query: &'a PreparedQuery, state: PagerState) -> ExecPager<'a, SessionPager<'a, M, S, T>> {
+    ExecPager {
+      pager: self,
+      pager_state: state,
       query,
     }
   }
@@ -98,8 +72,7 @@ impl<
   pub fn exec(&'a mut self, query: &'a PreparedQuery) -> ExecPager<'a, SessionPager<'a, M, S, T>> {
     ExecPager {
       pager: self,
-      paging_state: None,
-      has_more_pages: None,
+      pager_state: PagerState { cursor : None, has_more_pages : None},
       query,
     }
   }
@@ -107,8 +80,7 @@ impl<
 
 pub struct QueryPager<'a, Q: ToString, P: 'a> {
   pager: &'a mut P,
-  paging_state: Option<CBytes>,
-  has_more_pages: Option<bool>,
+  pager_state: PagerState,
   query: Q,
 }
 
@@ -122,8 +94,8 @@ impl<
 {
   pub fn next(&mut self) -> error::Result<Vec<Row>> {
     let mut params = QueryParamsBuilder::new().page_size(self.pager.page_size);
-    if self.paging_state.is_some() {
-      params = params.paging_state(self.paging_state.clone().unwrap());
+    if self.pager_state.cursor.is_some() {
+      params = params.paging_state(self.pager_state.cursor.clone().unwrap());
     }
 
     let body = self
@@ -137,45 +109,27 @@ impl<
       .ok_or("Pager query should yield a vector of rows".into());
     let metadata = metadata_res?;
 
-    self.has_more_pages = Some(RowsMetadataFlag::has_has_more_pages(metadata.flags.clone()));
-    self.paging_state = metadata.paging_state.clone();
+    self.pager_state.has_more_pages = Some(RowsMetadataFlag::has_has_more_pages(metadata.flags.clone()));
+    self.pager_state.cursor = metadata.paging_state.clone();
     body
       .into_rows()
       .ok_or("Pager query should yield a vector of rows".into())
   }
 
   pub fn has_more(&self) -> bool {
-    self.has_more_pages.unwrap_or(false)
+    self.pager_state.has_more_pages.unwrap_or(false)
   }
 
-
-  /// Unsigned byte is characterized by one byte or 8 bits.
-  /// Each unsigned byte can represent a number from 0 to 255,
-  /// so we can safely pack the state into 3 chars per byte.
-  pub fn pager_state(&self) -> Option<String> {
-    self.paging_state
-      .clone()
-      .and_then(|c_bytes| match c_bytes.as_slice() {
-        Some(u_vec) => {
-          let cap = u_vec.len() * 3;
-
-          let mut str_state: String = String::with_capacity(cap);
-
-          for byte in u_vec {
-            str_state.push_str(format!("{:03}", byte).as_str());
-          }
-
-          Some(str_state)
-        }
-        None => None
-      })
+  /// This method returns a copy of pager state so
+  /// the state may be used later for continuing paging.
+  pub fn pager_state(&self) -> PagerState {
+    self.pager_state.clone()
   }
 }
 
 pub struct ExecPager<'a, P: 'a> {
   pager: &'a mut P,
-  paging_state: Option<CBytes>,
-  has_more_pages: Option<bool>,
+  pager_state: PagerState,
   query: &'a PreparedQuery,
 }
 
@@ -188,8 +142,8 @@ impl<
 {
   pub fn next(&mut self) -> error::Result<Vec<Row>> {
     let mut params = QueryParamsBuilder::new().page_size(self.pager.page_size);
-    if self.paging_state.is_some() {
-      params = params.paging_state(self.paging_state.clone().unwrap());
+    if self.pager_state.cursor.is_some() {
+      params = params.paging_state(self.pager_state.cursor.clone().unwrap());
     }
 
     let body = self
@@ -203,14 +157,41 @@ impl<
       .ok_or("Pager query should yield a vector of rows".into());
     let metadata = metadata_res?;
 
-    self.has_more_pages = Some(RowsMetadataFlag::has_has_more_pages(metadata.flags.clone()));
-    self.paging_state = metadata.paging_state.clone();
+    self.pager_state.has_more_pages = Some(RowsMetadataFlag::has_has_more_pages(metadata.flags.clone()));
+    self.pager_state.cursor = metadata.paging_state.clone();
     body
       .into_rows()
       .ok_or("Pager query should yield a vector of rows".into())
   }
 
   pub fn has_more(&self) -> bool {
+    self.pager_state.has_more_pages.unwrap_or(false)
+  }
+
+  /// This method returns a copy of pager state so
+  /// the state may be used later for continuing paging.
+  pub fn pager_state(&self) -> PagerState {
+    self.pager_state.clone()
+  }
+}
+
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct PagerState {
+  cursor: Option<CBytes>,
+  has_more_pages: Option<bool>,
+}
+
+impl PagerState {
+  pub fn new() -> Self {
+    PagerState { cursor: None, has_more_pages: None }
+  }
+
+  pub fn has_more(&self) -> bool {
     self.has_more_pages.unwrap_or(false)
+  }
+
+  pub fn get_cursor(&self) -> Option<CBytes> {
+    self.cursor.clone()
   }
 }

--- a/src/cluster/pager.rs
+++ b/src/cluster/pager.rs
@@ -179,6 +179,14 @@ impl PagerState {
     PagerState { cursor: None, has_more_pages: None }
   }
 
+  pub fn with_cursor(cursor: CBytes) -> Self {
+    PagerState { cursor: Some(cursor), has_more_pages: None }
+  }
+
+  pub fn with_cursor_and_more_flag(cursor: CBytes, has_more: bool) -> Self {
+    PagerState { cursor: Some(cursor), has_more_pages: Some(has_more) }
+  }
+
   pub fn has_more(&self) -> bool {
     self.has_more_pages.unwrap_or(false)
   }

--- a/src/cluster/pager.rs
+++ b/src/cluster/pager.rs
@@ -54,11 +54,7 @@ impl<
   where
     Q: ToString,
   {
-    QueryPager {
-      pager: self,
-      pager_state: PagerState { cursor : None, has_more_pages : None},
-      query,
-    }
+    self.query_with_pager_state(query, PagerState { cursor : None, has_more_pages : None})
   }
 
   pub fn exec_with_pager_state(&'a mut self, query: &'a PreparedQuery, state: PagerState) -> ExecPager<'a, SessionPager<'a, M, S, T>> {
@@ -70,11 +66,7 @@ impl<
   }
 
   pub fn exec(&'a mut self, query: &'a PreparedQuery) -> ExecPager<'a, SessionPager<'a, M, S, T>> {
-    ExecPager {
-      pager: self,
-      pager_state: PagerState { cursor : None, has_more_pages : None},
-      query,
-    }
+    self.exec_with_pager_state(query, PagerState { cursor : None, has_more_pages : None})
   }
 }
 

--- a/src/cluster/pager.rs
+++ b/src/cluster/pager.rs
@@ -10,188 +10,182 @@ use transport::CDRSTransport;
 use types::rows::Row;
 use types::CBytes;
 
-pub struct SessionPager<
-  'a,
-  M: r2d2::ManageConnection<Connection = RefCell<T>, Error = error::Error> + Sized,
-  S: CDRSSession<'static, T, M> + 'a,
-  T: CDRSTransport + 'static,
-> {
-  page_size: i32,
-  session: &'a S,
-  transport_type: PhantomData<&'a T>,
-  connection_type: PhantomData<&'a M>,
+pub struct SessionPager<'a,
+ M: r2d2::ManageConnection<Connection = RefCell<T>, Error = error::Error>
+     + Sized,
+ S: CDRSSession<'static, T, M> + 'a,
+ T: CDRSTransport + 'static>
+{
+    page_size: i32,
+    session: &'a S,
+    transport_type: PhantomData<&'a T>,
+    connection_type: PhantomData<&'a M>,
 }
 
-impl<
-    'a,
-    'b: 'a,
-    M: r2d2::ManageConnection<Connection = RefCell<T>, Error = error::Error> + Sized,
-    S: CDRSSession<'static, T, M>,
-    T: CDRSTransport + 'static,
-  > SessionPager<'a, M, S, T>
+impl<'a,
+      'b: 'a,
+      M: r2d2::ManageConnection<Connection = RefCell<T>, Error = error::Error> + Sized,
+      S: CDRSSession<'static, T, M>,
+      T: CDRSTransport + 'static> SessionPager<'a, M, S, T>
 {
-  pub fn new(session: &'b S, page_size: i32) -> SessionPager<'a, M, S, T> {
-    SessionPager {
-      session,
-      page_size,
-      transport_type: PhantomData,
-      connection_type: PhantomData,
+    pub fn new(session: &'b S, page_size: i32) -> SessionPager<'a, M, S, T> {
+        SessionPager { session,
+                       page_size,
+                       transport_type: PhantomData,
+                       connection_type: PhantomData }
     }
-  }
 
-  pub fn query_with_pager_state<Q>(&'a mut self, query: Q, state: PagerState) -> QueryPager<'a, Q, SessionPager<'a, M, S, T>>
-    where
-      Q: ToString,
-  {
-    QueryPager {
-      pager: self,
-      pager_state : state,
-      query,
+    pub fn query_with_pager_state<Q>(&'a mut self,
+                                     query: Q,
+                                     state: PagerState)
+                                     -> QueryPager<'a, Q, SessionPager<'a, M, S, T>>
+        where Q: ToString
+    {
+        QueryPager { pager: self,
+                     pager_state: state,
+                     query }
     }
-  }
 
-  pub fn query<Q>(&'a mut self, query: Q) -> QueryPager<'a, Q, SessionPager<'a, M, S, T>>
-  where
-    Q: ToString,
-  {
-    self.query_with_pager_state(query, PagerState::new())
-  }
-
-  pub fn exec_with_pager_state(&'a mut self, query: &'a PreparedQuery, state: PagerState) -> ExecPager<'a, SessionPager<'a, M, S, T>> {
-    ExecPager {
-      pager: self,
-      pager_state: state,
-      query,
+    pub fn query<Q>(&'a mut self, query: Q) -> QueryPager<'a, Q, SessionPager<'a, M, S, T>>
+        where Q: ToString
+    {
+        self.query_with_pager_state(query, PagerState::new())
     }
-  }
 
-  pub fn exec(&'a mut self, query: &'a PreparedQuery) -> ExecPager<'a, SessionPager<'a, M, S, T>> {
-    self.exec_with_pager_state(query, PagerState::new())
-  }
+    pub fn exec_with_pager_state(&'a mut self,
+                                 query: &'a PreparedQuery,
+                                 state: PagerState)
+                                 -> ExecPager<'a, SessionPager<'a, M, S, T>> {
+        ExecPager { pager: self,
+                    pager_state: state,
+                    query }
+    }
+
+    pub fn exec(&'a mut self,
+                query: &'a PreparedQuery)
+                -> ExecPager<'a, SessionPager<'a, M, S, T>> {
+        self.exec_with_pager_state(query, PagerState::new())
+    }
 }
 
 pub struct QueryPager<'a, Q: ToString, P: 'a> {
-  pager: &'a mut P,
-  pager_state: PagerState,
-  query: Q,
+    pager: &'a mut P,
+    pager_state: PagerState,
+    query: Q,
 }
 
-impl<
-    'a,
-    Q: ToString,
-    T: CDRSTransport + 'static,
-    M: r2d2::ManageConnection<Connection = RefCell<T>, Error = error::Error> + Sized,
-    S: CDRSSession<'static, T, M>,
-  > QueryPager<'a, Q, SessionPager<'a, M, S, T>>
+impl<'a,
+      Q: ToString,
+      T: CDRSTransport + 'static,
+      M: r2d2::ManageConnection<Connection = RefCell<T>, Error = error::Error> + Sized,
+      S: CDRSSession<'static, T, M>> QueryPager<'a, Q, SessionPager<'a, M, S, T>>
 {
-  pub fn next(&mut self) -> error::Result<Vec<Row>> {
-    let mut params = QueryParamsBuilder::new().page_size(self.pager.page_size);
-    if self.pager_state.cursor.is_some() {
-      params = params.paging_state(self.pager_state.cursor.clone().unwrap());
+    pub fn next(&mut self) -> error::Result<Vec<Row>> {
+        let mut params = QueryParamsBuilder::new().page_size(self.pager.page_size);
+        if self.pager_state.cursor.is_some() {
+            params = params.paging_state(self.pager_state.cursor.clone().unwrap());
+        }
+
+        let body = self.pager
+                       .session
+                       .query_with_params(self.query.to_string(), params.finalize())
+                       .and_then(|frame| frame.get_body())?;
+
+        let metadata_res: error::Result<RowsMetadata> =
+            body.as_rows_metadata()
+                .ok_or("Pager query should yield a vector of rows".into());
+        let metadata = metadata_res?;
+
+        self.pager_state.has_more_pages =
+            Some(RowsMetadataFlag::has_has_more_pages(metadata.flags.clone()));
+        self.pager_state.cursor = metadata.paging_state.clone();
+        body.into_rows()
+            .ok_or("Pager query should yield a vector of rows".into())
     }
 
-    let body = self
-      .pager
-      .session
-      .query_with_params(self.query.to_string(), params.finalize())
-      .and_then(|frame| frame.get_body())?;
+    pub fn has_more(&self) -> bool {
+        self.pager_state.has_more_pages.unwrap_or(false)
+    }
 
-    let metadata_res: error::Result<RowsMetadata> = body
-      .as_rows_metadata()
-      .ok_or("Pager query should yield a vector of rows".into());
-    let metadata = metadata_res?;
-
-    self.pager_state.has_more_pages = Some(RowsMetadataFlag::has_has_more_pages(metadata.flags.clone()));
-    self.pager_state.cursor = metadata.paging_state.clone();
-    body
-      .into_rows()
-      .ok_or("Pager query should yield a vector of rows".into())
-  }
-
-  pub fn has_more(&self) -> bool {
-    self.pager_state.has_more_pages.unwrap_or(false)
-  }
-
-  /// This method returns a copy of pager state so
-  /// the state may be used later for continuing paging.
-  pub fn pager_state(&self) -> PagerState {
-    self.pager_state.clone()
-  }
+    /// This method returns a copy of pager state so
+    /// the state may be used later for continuing paging.
+    pub fn pager_state(&self) -> PagerState {
+        self.pager_state.clone()
+    }
 }
 
 pub struct ExecPager<'a, P: 'a> {
-  pager: &'a mut P,
-  pager_state: PagerState,
-  query: &'a PreparedQuery,
+    pager: &'a mut P,
+    pager_state: PagerState,
+    query: &'a PreparedQuery,
 }
 
-impl<
-    'a,
-    T: CDRSTransport + 'static,
-    M: r2d2::ManageConnection<Connection = RefCell<T>, Error = error::Error> + Sized,
-    S: CDRSSession<'static, T, M>,
-  > ExecPager<'a, SessionPager<'a, M, S, T>>
+impl<'a,
+      T: CDRSTransport + 'static,
+      M: r2d2::ManageConnection<Connection = RefCell<T>, Error = error::Error> + Sized,
+      S: CDRSSession<'static, T, M>> ExecPager<'a, SessionPager<'a, M, S, T>>
 {
-  pub fn next(&mut self) -> error::Result<Vec<Row>> {
-    let mut params = QueryParamsBuilder::new().page_size(self.pager.page_size);
-    if self.pager_state.cursor.is_some() {
-      params = params.paging_state(self.pager_state.cursor.clone().unwrap());
+    pub fn next(&mut self) -> error::Result<Vec<Row>> {
+        let mut params = QueryParamsBuilder::new().page_size(self.pager.page_size);
+        if self.pager_state.cursor.is_some() {
+            params = params.paging_state(self.pager_state.cursor.clone().unwrap());
+        }
+
+        let body = self.pager
+                       .session
+                       .exec_with_params(self.query, params.finalize())
+                       .and_then(|frame| frame.get_body())?;
+
+        let metadata_res: error::Result<RowsMetadata> =
+            body.as_rows_metadata()
+                .ok_or("Pager query should yield a vector of rows".into());
+        let metadata = metadata_res?;
+
+        self.pager_state.has_more_pages =
+            Some(RowsMetadataFlag::has_has_more_pages(metadata.flags.clone()));
+        self.pager_state.cursor = metadata.paging_state.clone();
+        body.into_rows()
+            .ok_or("Pager query should yield a vector of rows".into())
     }
 
-    let body = self
-      .pager
-      .session
-      .exec_with_params(self.query, params.finalize())
-      .and_then(|frame| frame.get_body())?;
+    pub fn has_more(&self) -> bool {
+        self.pager_state.has_more_pages.unwrap_or(false)
+    }
 
-    let metadata_res: error::Result<RowsMetadata> = body
-      .as_rows_metadata()
-      .ok_or("Pager query should yield a vector of rows".into());
-    let metadata = metadata_res?;
-
-    self.pager_state.has_more_pages = Some(RowsMetadataFlag::has_has_more_pages(metadata.flags.clone()));
-    self.pager_state.cursor = metadata.paging_state.clone();
-    body
-      .into_rows()
-      .ok_or("Pager query should yield a vector of rows".into())
-  }
-
-  pub fn has_more(&self) -> bool {
-    self.pager_state.has_more_pages.unwrap_or(false)
-  }
-
-  /// This method returns a copy of pager state so
-  /// the state may be used later for continuing paging.
-  pub fn pager_state(&self) -> PagerState {
-    self.pager_state.clone()
-  }
+    /// This method returns a copy of pager state so
+    /// the state may be used later for continuing paging.
+    pub fn pager_state(&self) -> PagerState {
+        self.pager_state.clone()
+    }
 }
-
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct PagerState {
-  cursor: Option<CBytes>,
-  has_more_pages: Option<bool>,
+    cursor: Option<CBytes>,
+    has_more_pages: Option<bool>,
 }
 
 impl PagerState {
-  pub fn new() -> Self {
-    PagerState { cursor: None, has_more_pages: None }
-  }
+    pub fn new() -> Self {
+        PagerState { cursor: None,
+                     has_more_pages: None }
+    }
 
-  pub fn with_cursor(cursor: CBytes) -> Self {
-    PagerState { cursor: Some(cursor), has_more_pages: None }
-  }
+    pub fn with_cursor(cursor: CBytes) -> Self {
+        PagerState { cursor: Some(cursor),
+                     has_more_pages: None }
+    }
 
-  pub fn with_cursor_and_more_flag(cursor: CBytes, has_more: bool) -> Self {
-    PagerState { cursor: Some(cursor), has_more_pages: Some(has_more) }
-  }
+    pub fn with_cursor_and_more_flag(cursor: CBytes, has_more: bool) -> Self {
+        PagerState { cursor: Some(cursor),
+                     has_more_pages: Some(has_more) }
+    }
 
-  pub fn has_more(&self) -> bool {
-    self.has_more_pages.unwrap_or(false)
-  }
+    pub fn has_more(&self) -> bool {
+        self.has_more_pages.unwrap_or(false)
+    }
 
-  pub fn get_cursor(&self) -> Option<CBytes> {
-    self.cursor.clone()
-  }
+    pub fn get_cursor(&self) -> Option<CBytes> {
+        self.cursor.clone()
+    }
 }

--- a/src/cluster/pager.rs
+++ b/src/cluster/pager.rs
@@ -12,14 +12,14 @@ use types::CBytes;
 
 pub struct SessionPager<'a,
  M: r2d2::ManageConnection<Connection = RefCell<T>, Error = error::Error>
-     + Sized,
+   + Sized,
  S: CDRSSession<'static, T, M> + 'a,
  T: CDRSTransport + 'static>
 {
-    page_size: i32,
-    session: &'a S,
-    transport_type: PhantomData<&'a T>,
-    connection_type: PhantomData<&'a M>,
+  page_size: i32,
+  session: &'a S,
+  transport_type: PhantomData<&'a T>,
+  connection_type: PhantomData<&'a M>,
 }
 
 impl<'a,
@@ -28,50 +28,48 @@ impl<'a,
       S: CDRSSession<'static, T, M>,
       T: CDRSTransport + 'static> SessionPager<'a, M, S, T>
 {
-    pub fn new(session: &'b S, page_size: i32) -> SessionPager<'a, M, S, T> {
-        SessionPager { session,
-                       page_size,
-                       transport_type: PhantomData,
-                       connection_type: PhantomData }
-    }
+  pub fn new(session: &'b S, page_size: i32) -> SessionPager<'a, M, S, T> {
+    SessionPager { session,
+                   page_size,
+                   transport_type: PhantomData,
+                   connection_type: PhantomData }
+  }
 
-    pub fn query_with_pager_state<Q>(&'a mut self,
-                                     query: Q,
-                                     state: PagerState)
-                                     -> QueryPager<'a, Q, SessionPager<'a, M, S, T>>
-        where Q: ToString
-    {
-        QueryPager { pager: self,
-                     pager_state: state,
-                     query }
-    }
+  pub fn query_with_pager_state<Q>(&'a mut self,
+                                   query: Q,
+                                   state: PagerState)
+                                   -> QueryPager<'a, Q, SessionPager<'a, M, S, T>>
+    where Q: ToString
+  {
+    QueryPager { pager: self,
+                 pager_state: state,
+                 query }
+  }
 
-    pub fn query<Q>(&'a mut self, query: Q) -> QueryPager<'a, Q, SessionPager<'a, M, S, T>>
-        where Q: ToString
-    {
-        self.query_with_pager_state(query, PagerState::new())
-    }
+  pub fn query<Q>(&'a mut self, query: Q) -> QueryPager<'a, Q, SessionPager<'a, M, S, T>>
+    where Q: ToString
+  {
+    self.query_with_pager_state(query, PagerState::new())
+  }
 
-    pub fn exec_with_pager_state(&'a mut self,
-                                 query: &'a PreparedQuery,
-                                 state: PagerState)
-                                 -> ExecPager<'a, SessionPager<'a, M, S, T>> {
-        ExecPager { pager: self,
-                    pager_state: state,
-                    query }
-    }
+  pub fn exec_with_pager_state(&'a mut self,
+                               query: &'a PreparedQuery,
+                               state: PagerState)
+                               -> ExecPager<'a, SessionPager<'a, M, S, T>> {
+    ExecPager { pager: self,
+                pager_state: state,
+                query }
+  }
 
-    pub fn exec(&'a mut self,
-                query: &'a PreparedQuery)
-                -> ExecPager<'a, SessionPager<'a, M, S, T>> {
-        self.exec_with_pager_state(query, PagerState::new())
-    }
+  pub fn exec(&'a mut self, query: &'a PreparedQuery) -> ExecPager<'a, SessionPager<'a, M, S, T>> {
+    self.exec_with_pager_state(query, PagerState::new())
+  }
 }
 
 pub struct QueryPager<'a, Q: ToString, P: 'a> {
-    pager: &'a mut P,
-    pager_state: PagerState,
-    query: Q,
+  pager: &'a mut P,
+  pager_state: PagerState,
+  query: Q,
 }
 
 impl<'a,
@@ -80,44 +78,44 @@ impl<'a,
       M: r2d2::ManageConnection<Connection = RefCell<T>, Error = error::Error> + Sized,
       S: CDRSSession<'static, T, M>> QueryPager<'a, Q, SessionPager<'a, M, S, T>>
 {
-    pub fn next(&mut self) -> error::Result<Vec<Row>> {
-        let mut params = QueryParamsBuilder::new().page_size(self.pager.page_size);
-        if self.pager_state.cursor.is_some() {
-            params = params.paging_state(self.pager_state.cursor.clone().unwrap());
-        }
-
-        let body = self.pager
-                       .session
-                       .query_with_params(self.query.to_string(), params.finalize())
-                       .and_then(|frame| frame.get_body())?;
-
-        let metadata_res: error::Result<RowsMetadata> =
-            body.as_rows_metadata()
-                .ok_or("Pager query should yield a vector of rows".into());
-        let metadata = metadata_res?;
-
-        self.pager_state.has_more_pages =
-            Some(RowsMetadataFlag::has_has_more_pages(metadata.flags.clone()));
-        self.pager_state.cursor = metadata.paging_state.clone();
-        body.into_rows()
-            .ok_or("Pager query should yield a vector of rows".into())
+  pub fn next(&mut self) -> error::Result<Vec<Row>> {
+    let mut params = QueryParamsBuilder::new().page_size(self.pager.page_size);
+    if self.pager_state.cursor.is_some() {
+      params = params.paging_state(self.pager_state.cursor.clone().unwrap());
     }
 
-    pub fn has_more(&self) -> bool {
-        self.pager_state.has_more_pages.unwrap_or(false)
-    }
+    let body = self.pager
+                   .session
+                   .query_with_params(self.query.to_string(), params.finalize())
+                   .and_then(|frame| frame.get_body())?;
 
-    /// This method returns a copy of pager state so
-    /// the state may be used later for continuing paging.
-    pub fn pager_state(&self) -> PagerState {
-        self.pager_state.clone()
-    }
+    let metadata_res: error::Result<RowsMetadata> =
+      body.as_rows_metadata()
+          .ok_or("Pager query should yield a vector of rows".into());
+    let metadata = metadata_res?;
+
+    self.pager_state.has_more_pages =
+      Some(RowsMetadataFlag::has_has_more_pages(metadata.flags.clone()));
+    self.pager_state.cursor = metadata.paging_state.clone();
+    body.into_rows()
+        .ok_or("Pager query should yield a vector of rows".into())
+  }
+
+  pub fn has_more(&self) -> bool {
+    self.pager_state.has_more_pages.unwrap_or(false)
+  }
+
+  /// This method returns a copy of pager state so
+  /// the state may be used later for continuing paging.
+  pub fn pager_state(&self) -> PagerState {
+    self.pager_state.clone()
+  }
 }
 
 pub struct ExecPager<'a, P: 'a> {
-    pager: &'a mut P,
-    pager_state: PagerState,
-    query: &'a PreparedQuery,
+  pager: &'a mut P,
+  pager_state: PagerState,
+  query: &'a PreparedQuery,
 }
 
 impl<'a,
@@ -125,67 +123,67 @@ impl<'a,
       M: r2d2::ManageConnection<Connection = RefCell<T>, Error = error::Error> + Sized,
       S: CDRSSession<'static, T, M>> ExecPager<'a, SessionPager<'a, M, S, T>>
 {
-    pub fn next(&mut self) -> error::Result<Vec<Row>> {
-        let mut params = QueryParamsBuilder::new().page_size(self.pager.page_size);
-        if self.pager_state.cursor.is_some() {
-            params = params.paging_state(self.pager_state.cursor.clone().unwrap());
-        }
-
-        let body = self.pager
-                       .session
-                       .exec_with_params(self.query, params.finalize())
-                       .and_then(|frame| frame.get_body())?;
-
-        let metadata_res: error::Result<RowsMetadata> =
-            body.as_rows_metadata()
-                .ok_or("Pager query should yield a vector of rows".into());
-        let metadata = metadata_res?;
-
-        self.pager_state.has_more_pages =
-            Some(RowsMetadataFlag::has_has_more_pages(metadata.flags.clone()));
-        self.pager_state.cursor = metadata.paging_state.clone();
-        body.into_rows()
-            .ok_or("Pager query should yield a vector of rows".into())
+  pub fn next(&mut self) -> error::Result<Vec<Row>> {
+    let mut params = QueryParamsBuilder::new().page_size(self.pager.page_size);
+    if self.pager_state.cursor.is_some() {
+      params = params.paging_state(self.pager_state.cursor.clone().unwrap());
     }
 
-    pub fn has_more(&self) -> bool {
-        self.pager_state.has_more_pages.unwrap_or(false)
-    }
+    let body = self.pager
+                   .session
+                   .exec_with_params(self.query, params.finalize())
+                   .and_then(|frame| frame.get_body())?;
 
-    /// This method returns a copy of pager state so
-    /// the state may be used later for continuing paging.
-    pub fn pager_state(&self) -> PagerState {
-        self.pager_state.clone()
-    }
+    let metadata_res: error::Result<RowsMetadata> =
+      body.as_rows_metadata()
+          .ok_or("Pager query should yield a vector of rows".into());
+    let metadata = metadata_res?;
+
+    self.pager_state.has_more_pages =
+      Some(RowsMetadataFlag::has_has_more_pages(metadata.flags.clone()));
+    self.pager_state.cursor = metadata.paging_state.clone();
+    body.into_rows()
+        .ok_or("Pager query should yield a vector of rows".into())
+  }
+
+  pub fn has_more(&self) -> bool {
+    self.pager_state.has_more_pages.unwrap_or(false)
+  }
+
+  /// This method returns a copy of pager state so
+  /// the state may be used later for continuing paging.
+  pub fn pager_state(&self) -> PagerState {
+    self.pager_state.clone()
+  }
 }
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct PagerState {
-    cursor: Option<CBytes>,
-    has_more_pages: Option<bool>,
+  cursor: Option<CBytes>,
+  has_more_pages: Option<bool>,
 }
 
 impl PagerState {
-    pub fn new() -> Self {
-        PagerState { cursor: None,
-                     has_more_pages: None }
-    }
+  pub fn new() -> Self {
+    PagerState { cursor: None,
+                 has_more_pages: None }
+  }
 
-    pub fn with_cursor(cursor: CBytes) -> Self {
-        PagerState { cursor: Some(cursor),
-                     has_more_pages: None }
-    }
+  pub fn with_cursor(cursor: CBytes) -> Self {
+    PagerState { cursor: Some(cursor),
+                 has_more_pages: None }
+  }
 
-    pub fn with_cursor_and_more_flag(cursor: CBytes, has_more: bool) -> Self {
-        PagerState { cursor: Some(cursor),
-                     has_more_pages: Some(has_more) }
-    }
+  pub fn with_cursor_and_more_flag(cursor: CBytes, has_more: bool) -> Self {
+    PagerState { cursor: Some(cursor),
+                 has_more_pages: Some(has_more) }
+  }
 
-    pub fn has_more(&self) -> bool {
-        self.has_more_pages.unwrap_or(false)
-    }
+  pub fn has_more(&self) -> bool {
+    self.has_more_pages.unwrap_or(false)
+  }
 
-    pub fn get_cursor(&self) -> Option<CBytes> {
-        self.cursor.clone()
-    }
+  pub fn get_cursor(&self) -> Option<CBytes> {
+    self.cursor.clone()
+  }
 }


### PR DESCRIPTION
I had to implement pagination for stateless connections (HTTP) and your API does not allow to pull the internal state of the pager. So, I have injected the pager state when you ask for execute a new query and obtain the same state from the pager.

PS: I am not very comfortable with Rust, if you see that I have a mistake, please let me know. 

Thanks.