### PR TITLE
#296 Removed the extra 4 bytes from the auth response

### DIFF
--- a/src/cluster/tcp_connection_pool.rs
+++ b/src/cluster/tcp_connection_pool.rs
@@ -125,7 +125,7 @@ pub fn startup<'b, T: CDRSTransport + 'static, A: Authenticator + 'static + Size
             return Err(err);
         }
 
-        let auth_token_bytes = session_authenticator.get_auth_token().into_cbytes();
+        let auth_token_bytes = session_authenticator.get_auth_token();
         transport.borrow_mut().write(
             Frame::new_req_auth_response(auth_token_bytes)
                 .into_cbytes()

--- a/src/frame/frame_auth_response.rs
+++ b/src/frame/frame_auth_response.rs
@@ -24,12 +24,12 @@ impl IntoBytes for BodyReqAuthResponse {
 
 impl Frame {
     /// Creates new frame of type `AuthResponse`.
-    pub fn new_req_auth_response(bytes: Vec<u8>) -> Frame {
+    pub fn new_req_auth_response(token_bytes: CBytes) -> Frame {
         let version = Version::Request;
         let flag = Flag::Ignore;
         let stream = rand::random::<u16>();
         let opcode = Opcode::AuthResponse;
-        let body = BodyReqAuthResponse::new(CBytes::new(bytes));
+        let body = BodyReqAuthResponse::new(token_bytes);
 
         Frame {
             version: version,
@@ -60,7 +60,7 @@ mod tests {
     #[test]
     fn frame_body_req_auth_response() {
         let bytes = vec![1, 2, 3];
-        let frame = Frame::new_req_auth_response(bytes);
+        let frame = Frame::new_req_auth_response(CBytes::new(bytes));
 
         assert_eq!(frame.version, Version::Request);
         assert_eq!(frame.flags, vec![Flag::Ignore]);


### PR DESCRIPTION
> Only one thing. I like the original idea to have a separate structure for each type of body. So if we can agree that this already contains bytes then we can modify new_req_auth_response in following way:

Yes, I totally agree.

I made those changes and have tested, I have to add the uuid dep #298 and have removed it for this PR.

If it is anything wrong, please tell me :+1: 

thank you once more.